### PR TITLE
Fix font path joining for pdf services

### DIFF
--- a/express/services/pdf/pdfService.js
+++ b/express/services/pdf/pdfService.js
@@ -49,7 +49,7 @@ async function generateCertificate(filePath, originalName, previewUrl) {
       const doc = new PDFDocument({ autoFirstPage: true });
 
       // ★★ [核心] 註冊自訂(中文)字體路徑 (請依實際調整) ★★
-      const fontPath = path.join(__dirname, '../../..', 'fonts', 'NotoSansTC-VariableFont_wght.ttf');
+      const fontPath = path.join(__dirname, '../../fonts', 'NotoSansTC-VariableFont_wght.ttf');
       doc.registerFont('NotoSansTC', fontPath);
       doc.font('NotoSansTC');
 
@@ -107,7 +107,7 @@ async function generateReport(filePath, results) {
       const doc = new PDFDocument({ autoFirstPage: true });
 
       // ★★ [核心] 註冊字體
-      const fontPath = path.join(__dirname, '../../..', 'fonts', 'NotoSansTC-VariableFont_wght.ttf');
+      const fontPath = path.join(__dirname, '../../fonts', 'NotoSansTC-VariableFont_wght.ttf');
       doc.registerFont('NotoSansTC', fontPath);
       doc.font('NotoSansTC');
 
@@ -182,7 +182,7 @@ async function generateScanPDFWithMatches(
       const doc = new PDFDocument({ autoFirstPage: true });
 
       // ★★ [核心] 註冊字體 (中文)
-      const fontPath = path.join(__dirname, '../../..', 'fonts', 'NotoSansTC-VariableFont_wght.ttf');
+      const fontPath = path.join(__dirname, '../../fonts', 'NotoSansTC-VariableFont_wght.ttf');
       doc.registerFont('NotoSansTC', fontPath);
       doc.font('NotoSansTC');
 
@@ -280,7 +280,7 @@ async function generateSearchReport(results) {
       const doc = new PDFDocument({ autoFirstPage: false });
 
       // 同樣註冊中文字體
-      const fontPath = path.join(__dirname, '../../..', 'fonts', 'NotoSansTC-VariableFont_wght.ttf');
+      const fontPath = path.join(__dirname, '../../fonts', 'NotoSansTC-VariableFont_wght.ttf');
       doc.registerFont('NotoSansTC', fontPath);
       doc.font('NotoSansTC');
 

--- a/express/services/pdfService.js
+++ b/express/services/pdfService.js
@@ -40,7 +40,7 @@ async function generateCertificate(filePath, originalName, previewUrl) {
 
       // ★★★ [核心] 註冊自訂字體 (中文) ★★★
       // 請注意此路徑需依您實際字體位置做相對/絕對修正
-      const fontPath = path.join(__dirname, '../../fonts/NotoSansTC-VariableFont_wght.ttf');
+      const fontPath = path.join(__dirname, '../fonts/NotoSansTC-VariableFont_wght.ttf');
       doc.registerFont('NotoSansTC', fontPath);
 
       // 之後預設全程使用這個字體
@@ -95,7 +95,7 @@ async function generateReport(filePath, results) {
       const doc = new PDFDocument({ autoFirstPage: true });
 
       // ★★★ [核心] 註冊自訂字體 (中文) ★★★
-      const fontPath = path.join(__dirname, '../../fonts/NotoSansTC-VariableFont_wght.ttf');
+      const fontPath = path.join(__dirname, '../fonts/NotoSansTC-VariableFont_wght.ttf');
       doc.registerFont('NotoSansTC', fontPath);
       doc.font('NotoSansTC');
 
@@ -169,7 +169,7 @@ async function generateScanPDFWithMatches(
       const doc = new PDFDocument({ autoFirstPage: true });
 
       // ★★★ [核心] 註冊自訂字體 (中文) ★★★
-      const fontPath = path.join(__dirname, '../../fonts/NotoSansTC-VariableFont_wght.ttf');
+      const fontPath = path.join(__dirname, '../fonts/NotoSansTC-VariableFont_wght.ttf');
       doc.registerFont('NotoSansTC', fontPath);
       doc.font('NotoSansTC');
 


### PR DESCRIPTION
## Summary
- correct font path for `/app/services` and `/app/services/pdf`

## Testing
- `npm test --silent` *(fails: no tests defined)*
- `node - <<'EOF'
const pdfSvc = require('./express/services/pdfService');
(async () => {
  try {
    const p = await pdfSvc.generateCertificate('preCollectedImages/brandA_logo1.jpg','brandA_logo1.jpg','preCollectedImages/brandA_logo1.jpg');
    console.log('generated at', p);
  } catch(e) {
    console.log('error', e.message);
  }
})();
EOF` *(fails: Cannot find module 'pdfkit')*

------
https://chatgpt.com/codex/tasks/task_e_6843f7e8d8b883248c5fd293d4f7ede1