### PR TITLE
Use env-based headless option for Puppeteer

### DIFF
--- a/express/routes/protect.js
+++ b/express/routes/protect.js
@@ -123,9 +123,13 @@ function ensureDebugShotsDir(){
 ensureDebugShotsDir();
 
 async function launchBrowser(){
-  console.log('[launchBrowser] starting stealth browser...');
+  // Mirror utils/browserHelper.js logic for determining headless mode
+  const envHeadless = process.env.PPTR_HEADLESS ?? process.env.PUPPETEER_HEADLESS;
+  const HEADLESS = envHeadless === 'false' ? false : true;
+  console.log('[launchBrowser] starting stealth browser... headless=', HEADLESS);
+
   return puppeteer.launch({
-    headless: true,
+    headless: HEADLESS ? 'new' : false,
     executablePath: process.env.CHROMIUM_PATH || undefined,
     args:[
       '--no-sandbox',


### PR DESCRIPTION
## Summary
- update `launchBrowser` in `express/routes/protect.js` to mirror the logic in `utils/browserHelper.js`
- check `PPTR_HEADLESS` or `PUPPETEER_HEADLESS` and pass `'new'` when headless is enabled

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844867e59b48324ae0eb4b2853365ba