### PR TITLE
Fix vector search service URL

### DIFF
--- a/express/utils/vectorSearch.js
+++ b/express/utils/vectorSearch.js
@@ -7,7 +7,8 @@ const fs = require('fs');
 const axios = require('axios');
 const FormData = require('form-data');
 
-const PYTHON_VECTOR_SERVICE_URL = process.env.PYTHON_VECTOR_SERVICE_URL || 'http://python-vector-service:8000';
+// 可以透過環境變數覆蓋服務 URL，預設使用 docker-compose 內的 container name
+const PYTHON_VECTOR_SERVICE_URL = process.env.PYTHON_VECTOR_SERVICE_URL || 'http://suzoo_python_vector:8000';
 const INDEX_ENDPOINT = `${PYTHON_VECTOR_SERVICE_URL}/api/v1/index`;
 const SEARCH_ENDPOINT = `${PYTHON_VECTOR_SERVICE_URL}/api/v1/search`;
 

--- a/vectorSearch.js
+++ b/vectorSearch.js
@@ -5,8 +5,8 @@ const fs = require('fs');
 const FormData = require('form-data');
 const axios = require('axios');
 
-// ★ 依您實際部署位置修改
-const VECTOR_SERVICE_BASE_URL = 'http://python-vector-service:8000';
+// 服務位置可由環境變數覆蓋，預設為 docker-compose 中的 container name
+const VECTOR_SERVICE_BASE_URL = process.env.PYTHON_VECTOR_SERVICE_URL || 'http://suzoo_python_vector:8000';
 
 // 將單張圖片索引到 Milvus
 async function indexImageVector(localImagePath, fileId) {


### PR DESCRIPTION
## Summary
- update `express/utils/vectorSearch.js` to default to `http://suzoo_python_vector:8000`
- update root `vectorSearch.js` with same default and env override

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68448680d5408324bda5bd36423758ec