### PR TITLE
Add credential path logging and auth hints

### DIFF
--- a/express/services/visionService.js
+++ b/express/services/visionService.js
@@ -25,11 +25,20 @@ let visionClient;
 function getClient() {
   if (!visionClient) {
     const keyFile = process.env.GOOGLE_APPLICATION_CREDENTIALS || DEFAULT_KEY_FILE;
+    console.log(`[visionService] using credential file: ${keyFile}`);
     if (!fs.existsSync(keyFile)) {
       console.error(`[visionService] credential file missing: ${keyFile}`);
       throw new Error(`GOOGLE_APPLICATION_CREDENTIALS file not found at ${keyFile}`);
     }
-    visionClient = new vision.ImageAnnotatorClient({ keyFilename: keyFile });
+    try {
+      visionClient = new vision.ImageAnnotatorClient({ keyFilename: keyFile });
+    } catch (err) {
+      console.error('[visionService] failed to create Vision client =>', err.message);
+      if (err.code === 16) { // UNAUTHENTICATED
+        console.error('[visionService] authentication failed. Check your credential file and GOOGLE_APPLICATION_CREDENTIALS env variable.');
+      }
+      throw err;
+    }
   }
   return visionClient;
 }


### PR DESCRIPTION
## Summary
- log the chosen credential file in `getClient`
- warn when authentication fails with hint to check the credential file and `GOOGLE_APPLICATION_CREDENTIALS`

## Testing
- `npm run --silent vision:test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68465038cf7c832482d1e8ee6d89387a