### PR TITLE
Add simple Vision API test

### DIFF
--- a/express/tests/vision.test.js
+++ b/express/tests/vision.test.js
@@ -1,0 +1,18 @@
+const vision = require('@google-cloud/vision');
+const path = require('path');
+
+(async () => {
+  const keyFile = process.env.GOOGLE_APPLICATION_CREDENTIALS ||
+    path.resolve(__dirname, '../../credentials/gcp-vision.json');
+  const client = new vision.ImageAnnotatorClient({ keyFilename: keyFile });
+
+  const img = path.resolve(__dirname, '../../preCollectedImages/brandA_logo1.jpg');
+  try {
+    const [result] = await client.labelDetection(img);
+    const labels = (result.labelAnnotations || []).map(l => l.description);
+    console.log('Vision labels:', labels.slice(0, 3));
+  } catch (err) {
+    console.error('Vision test failed:', err.message);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add `vision.test.js` to exercise Google Cloud Vision client

## Testing
- `npm run vision:test --prefix express` *(fails: Cannot find module '@google-cloud/vision')*

------
https://chatgpt.com/codex/tasks/task_e_6846503a671c8324ae90f32b952c718d