### PR TITLE
Add TinEye API search service

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,15 @@ docker-compose up --build
 3. 在 `.env` 或 Docker Compose 內設定環境變數：
 
    ```bash
-   GOOGLE_APPLICATION_CREDENTIALS=/app/credentials/gcp-vision.json
-   ```
+  GOOGLE_APPLICATION_CREDENTIALS=/app/credentials/gcp-vision.json
+  ```
 
 4. 為避免洩漏，`credentials/*.json` 已加入 `.gitignore`，可改以 `credentials/gcp-vision.json.example` 提供範例檔。
+
+## TinEye API
+
+若要啟用 TinEye 以圖搜尋，請在 `.env` 檔加入：
+
+```bash
+TINEYE_API_KEY=your_tineye_api_key
+```

--- a/express/routes/searchRoutes.js
+++ b/express/routes/searchRoutes.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const router = express.Router();
+
+const { searchTinEyeApi } = require('../services/tineyeService');
+
+// POST /api/search/tineye
+router.post('/search/tineye', async (req, res) => {
+  const { imageUrl } = req.body || {};
+  if (!imageUrl) {
+    return res.status(400).json({ error: 'imageUrl required' });
+  }
+  try {
+    const matches = await searchTinEyeApi(imageUrl);
+    return res.json({ matches });
+  } catch (err) {
+    console.error('[POST /api/search/tineye] error =>', err.message || err);
+    return res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/express/server.js
+++ b/express/server.js
@@ -9,6 +9,7 @@ const paymentRoutes = require('./routes/paymentRoutes');
 const protectRouter = require('./routes/protect');
 const adminRouter   = require('./routes/admin');
 const authRouter    = require('./routes/authRoutes');
+const searchRoutes  = require('./routes/searchRoutes');
 
 const fs   = require('fs');
 const path = require('path');
@@ -44,6 +45,7 @@ app.get('/health', (req, res) => {
  | 4. 掛載各路由
  *──────────────────────────────────────────────*/
 app.use('/api',          paymentRoutes);
+app.use('/api',          searchRoutes);
 app.use('/api/protect',  protectRouter);
 app.use('/admin',        adminRouter);
 app.use('/auth',         authRouter);

--- a/express/services/tineyeService.js
+++ b/express/services/tineyeService.js
@@ -1,0 +1,39 @@
+require('dotenv').config();
+const axios = require('axios');
+
+const API_URL = 'https://api.tineye.com/rest/search/';
+
+/**
+ * Search TinEye API with a remote image URL.
+ * @param {string} imageUrl
+ * @returns {Promise<Array<{url:string, score:number, source:string}>>}
+ */
+async function searchTinEyeApi(imageUrl){
+  const apiKey = process.env.TINEYE_API_KEY;
+  if(!apiKey){
+    throw new Error('TINEYE_API_KEY not set');
+  }
+  if(!imageUrl){
+    throw new Error('imageUrl is required');
+  }
+
+  const resp = await axios.get(API_URL, {
+    params: {
+      image_url: imageUrl,
+      api_key: apiKey
+    },
+    timeout: 10000
+  });
+
+  const matches = resp.data && resp.data.result && Array.isArray(resp.data.result.matches)
+    ? resp.data.result.matches
+    : [];
+
+  return matches.map(m => ({
+    url: m.backlinks && m.backlinks[0] && m.backlinks[0].url ? m.backlinks[0].url : '',
+    score: m.score,
+    source: m.image_url
+  }));
+}
+
+module.exports = { searchTinEyeApi };


### PR DESCRIPTION
## Summary
- add TinEye API service using axios
- expose `/api/search/tineye` route
- register searchRoutes in Express server
- document `TINEYE_API_KEY` in README

## Testing
- `npm --prefix express install` *(fails: chromium download 403)*
- `npm --prefix express run vision:test` *(fails: missing module)*

------
https://chatgpt.com/codex/tasks/task_e_68466d3e296c832488fcb8e4e78f6fb4