### PR TITLE
Export aggregator search utility

### DIFF
--- a/express/services/aggregatorSearchLink.js
+++ b/express/services/aggregatorSearchLink.js
@@ -1,3 +1,5 @@
+const puppeteer = require('puppeteer');
+
 /**
  * 嘗試關閉廣告 - 可根據實際網頁 HTML 結構修改 selector
  */
@@ -216,3 +218,10 @@ async function aggregatorSearchGinifabStrict(localFilePath='', publicImageUrl=''
 
   return results;
 }
+
+module.exports = {
+  aggregatorSearchGinifabStrict,
+  tryCloseAd,
+  tryClickUploadLocal,
+  tryClickSpecifyImageUrl
+};


### PR DESCRIPTION
## Summary
- add puppeteer dependency to `aggregatorSearchLink.js`
- export `aggregatorSearchGinifabStrict` and helpers

## Testing
- `npm --prefix express run vision:test` *(fails: cannot find module '@google-cloud/vision')*

------
https://chatgpt.com/codex/tasks/task_e_68466d40d0d883249d41795f84335b83