### PR TITLE
Expand Vision URL extraction

### DIFF
--- a/express/services/visionService.js
+++ b/express/services/visionService.js
@@ -129,9 +129,12 @@ async function getVisionPageMatches(filePath, maxResults = 10) {
       image: { content: buf },
       maxResults,
     });
-    urls = (res.webDetection?.pagesWithMatchingImages || [])
-      .map((p) => p.url)
-      .filter(isValidLink);
+    const wd = res.webDetection || {};
+    urls = [
+      ...(wd.pagesWithMatchingImages || []).map(p => p.url),
+      ...(wd.fullMatchingImages || []).map(i => i.url),
+      ...(wd.partialMatchingImages || []).map(i => i.url)
+    ].filter(isValidLink);
   } catch (err) {
     console.error('[visionService] getVisionPageMatches fail =>', err.message);
     return [];


### PR DESCRIPTION
## Summary
- include fullMatchingImages and partialMatchingImages in Google Vision detection
- ensure all collected links pass through URL validation

## Testing
- `npm run vision:test` *(fails: Cannot find module '@google-cloud/vision')*

------
https://chatgpt.com/codex/tasks/task_e_68466d41e368832486d87a2c9aee710a