### PR TITLE
Add searchMilvus route for vector search

### DIFF
--- a/express/routes/searchMilvus.js
+++ b/express/routes/searchMilvus.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const axios = require('axios');
+
+const router = express.Router();
+
+const VECTOR_SEARCH_URL = process.env.VECTOR_SEARCH_URL || 'http://suzoo_python_vector:8000/vector/search';
+
+router.post('/milvus', async (req, res) => {
+  try {
+    const { imageBase64, topK } = req.body;
+    if (!imageBase64) {
+      return res.status(400).json({ error: 'imageBase64 is required' });
+    }
+
+    const payload = { imageBase64 };
+    if (topK !== undefined) payload.topK = topK;
+
+    const response = await axios.post(VECTOR_SEARCH_URL, payload, { timeout: 30000 });
+    return res.json(response.data);
+  } catch (err) {
+    console.error('[searchMilvus] error:', err.message);
+    if (err.response) {
+      return res.status(err.response.status).json(err.response.data);
+    }
+    return res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/express/server.js
+++ b/express/server.js
@@ -9,6 +9,7 @@ const paymentRoutes = require('./routes/paymentRoutes');
 const protectRouter = require('./routes/protect');
 const adminRouter   = require('./routes/admin');
 const authRouter    = require('./routes/authRoutes');
+const searchMilvusRouter = require('./routes/searchMilvus');
 
 const fs   = require('fs');
 const path = require('path');
@@ -44,6 +45,7 @@ app.get('/health', (req, res) => {
  | 4. 掛載各路由
  *──────────────────────────────────────────────*/
 app.use('/api',          paymentRoutes);
+app.use('/api/search',  searchMilvusRouter);
 app.use('/api/protect',  protectRouter);
 app.use('/admin',        adminRouter);
 app.use('/auth',         authRouter);


### PR DESCRIPTION
## Summary
- add new route `routes/searchMilvus.js` for Milvus vector search
- register the new router in `express/server.js`

## Testing
- `npm run vision:test` *(fails: Cannot find module '@google-cloud/vision')*

------
https://chatgpt.com/codex/tasks/task_e_68466d429f5083248f61bc1967ffd10b