### PR TITLE
Add search report generation API

### DIFF
--- a/express/routes/report.js
+++ b/express/routes/report.js
@@ -1,0 +1,28 @@
+const express = require('express');
+const router = express.Router();
+const path = require('path');
+const { generateSearchReport } = require('../services/pdf/pdfService');
+
+/**
+ * POST /api/report/search
+ * 接收各搜尋引擎結果 (連結、截圖等)，生成 PDF 報告
+ * body: { results: Array<{engine, screenshotPath, links:[]} > }
+ */
+router.post('/report/search', async (req, res) => {
+  try {
+    const { results } = req.body;
+    if (!Array.isArray(results) || !results.length) {
+      return res.status(400).json({ error: 'Invalid results payload' });
+    }
+
+    const pdfPath = await generateSearchReport(results);
+    const pdfUrl = `/uploads/${path.basename(pdfPath)}`;
+
+    return res.json({ report: pdfUrl, path: pdfPath });
+  } catch (err) {
+    console.error('[POST /report/search] Error:', err);
+    return res.status(500).json({ error: 'Failed to generate search report' });
+  }
+});
+
+module.exports = router;

--- a/express/server.js
+++ b/express/server.js
@@ -9,6 +9,7 @@ const paymentRoutes = require('./routes/paymentRoutes');
 const protectRouter = require('./routes/protect');
 const adminRouter   = require('./routes/admin');
 const authRouter    = require('./routes/authRoutes');
+const reportRouter  = require('./routes/report');
 
 const fs   = require('fs');
 const path = require('path');
@@ -47,6 +48,7 @@ app.use('/api',          paymentRoutes);
 app.use('/api/protect',  protectRouter);
 app.use('/admin',        adminRouter);
 app.use('/auth',         authRouter);
+app.use('/api',          reportRouter);
 
 /*──────────────────────────────────────────────
  | 5. Sequelize 連線 & 同步


### PR DESCRIPTION
## Summary
- implement a `/api/report/search` endpoint for creating search result PDFs
- mount the new route in the Express server

## Testing
- `npm run vision:test` *(fails: module not found or Puppeteer install)*

------
https://chatgpt.com/codex/tasks/task_e_68466d43f5688324b2046c856fce30b4