### PR TITLE
Export GinifabStrict aggregator

### DIFF
--- a/express/services/aggregatorSearchLink.js
+++ b/express/services/aggregatorSearchLink.js
@@ -1,3 +1,5 @@
+const puppeteer = require('puppeteer');
+
 /**
  * 嘗試關閉廣告 - 可根據實際網頁 HTML 結構修改 selector
  */
@@ -216,3 +218,5 @@ async function aggregatorSearchGinifabStrict(localFilePath='', publicImageUrl=''
 
   return results;
 }
+
+module.exports = { aggregatorSearchGinifabStrict };


### PR DESCRIPTION
## Summary
- load puppeteer at the top of `aggregatorSearchLink.js`
- export `aggregatorSearchGinifabStrict`

## Testing
- `npm run vision:test` *(fails: Cannot find module '@google-cloud/vision')*

------
https://chatgpt.com/codex/tasks/task_e_68466d468c1c83248a212089dffe9c2a