### PR TITLE
Add TinEye API search endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,11 @@ docker-compose up --build
    ```
 
 4. 為避免洩漏，`credentials/*.json` 已加入 `.gitignore`，可改以 `credentials/gcp-vision.json.example` 提供範例檔。
+
+## TinEye API
+
+若要啟用 TinEye 反向圖搜尋，請在 `.env` 中設定：
+
+```bash
+TINEYE_API_KEY=your_tineye_key
+```

--- a/express/routes/searchRoutes.js
+++ b/express/routes/searchRoutes.js
@@ -1,0 +1,26 @@
+/*************************************************************
+ * express/routes/searchRoutes.js
+ *
+ * - /api/search/tineye
+ *************************************************************/
+const express = require('express');
+const router = express.Router();
+const { searchTinEyeApi } = require('../services/tineyeService');
+
+// POST /api/search/tineye { imageUrl: "..." }
+router.post('/search/tineye', async (req, res) => {
+  const { imageUrl } = req.body || {};
+  if (!imageUrl) {
+    return res.status(400).json({ error: 'imageUrl required' });
+  }
+
+  try {
+    const matches = await searchTinEyeApi(imageUrl);
+    res.json({ matches });
+  } catch (err) {
+    console.error('[searchTinEyeApi]', err.message);
+    res.status(500).json({ error: 'TinEye search failed' });
+  }
+});
+
+module.exports = router;

--- a/express/server.js
+++ b/express/server.js
@@ -9,6 +9,7 @@ const paymentRoutes = require('./routes/paymentRoutes');
 const protectRouter = require('./routes/protect');
 const adminRouter   = require('./routes/admin');
 const authRouter    = require('./routes/authRoutes');
+const searchRoutes  = require('./routes/searchRoutes');
 
 const fs   = require('fs');
 const path = require('path');
@@ -44,6 +45,7 @@ app.get('/health', (req, res) => {
  | 4. 掛載各路由
  *──────────────────────────────────────────────*/
 app.use('/api',          paymentRoutes);
+app.use('/api',          searchRoutes);
 app.use('/api/protect',  protectRouter);
 app.use('/admin',        adminRouter);
 app.use('/auth',         authRouter);

--- a/express/services/tineyeService.js
+++ b/express/services/tineyeService.js
@@ -1,0 +1,33 @@
+const axios = require('axios');
+
+const TINEYE_ENDPOINT = 'https://api.tineye.com/rest/search/';
+
+/**
+ * Query the TinEye API for matches.
+ * @param {string} imageUrl - URL of the image to search.
+ * @returns {Promise<Array<{url:string, score:number, source:string}>>}
+ */
+async function searchTinEyeApi(imageUrl) {
+  const apiKey = process.env.TINEYE_API_KEY;
+  if (!apiKey) {
+    throw new Error('TINEYE_API_KEY is not set');
+  }
+
+  try {
+    const { data } = await axios.get(TINEYE_ENDPOINT, {
+      params: { image_url: imageUrl, api_key: apiKey }
+    });
+
+    const matches = ((data || {}).results || {}).matches || [];
+    return matches.map(m => ({
+      url: (m.backlinks && m.backlinks[0] && m.backlinks[0].url) || '',
+      score: m.score,
+      source: m.domain || m.site
+    }));
+  } catch (err) {
+    console.error('[TinEye API] error:', err.message);
+    throw err;
+  }
+}
+
+module.exports = { searchTinEyeApi };


### PR DESCRIPTION
## Summary
- add TinEye API service using axios
- expose POST `/api/search/tineye` route
- mount new route in server
- document `TINEYE_API_KEY` env variable

## Testing
- `npm run vision:test` *(fails: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68466d472a4c83248334791bd7da26a2