### PR TITLE
Fix baiduCrawler path

### DIFF
--- a/express/services/infringementService.js
+++ b/express/services/infringementService.js
@@ -5,7 +5,7 @@ const { launchBrowser } = require('../../utils/browserHelper');
 const { searchGinifab } = require('./crawlers/ginifabCrawler');
 const { searchBing } = require('./crawlers/bingCrawler');
 const { searchTinEye } = require('./crawlers/tinEyeCrawler');
-const { searchBaidu } = require('./baiduCrawler');  // or crawlers/baiduCrawler
+const { searchBaidu } = require('./crawlers/baiduCrawler');
 // optional: 也可將 ginifabEngine(增強版) 直接放這裡
 
 /**


### PR DESCRIPTION
## Summary
- point infringementService to use baiduCrawler from crawlers folder

## Testing
- `npm --prefix express run vision:test` *(fails: Cannot find module '@google-cloud/vision')*

------
https://chatgpt.com/codex/tasks/task_e_68466d47a4908324acd047d2269b47c8