### PR TITLE
Add Milvus search endpoint

### DIFF
--- a/express/routes/searchMilvus.js
+++ b/express/routes/searchMilvus.js
@@ -1,0 +1,34 @@
+const express = require('express');
+const router = express.Router();
+const axios = require('axios');
+
+const VECTOR_SERVICE_URL = process.env.PYTHON_VECTOR_SERVICE_URL || 'http://suzoo_python_vector:8000';
+
+/**
+ * POST /api/search/milvus
+ * Body: { imageBase64: string, topK?: number }
+ * Forward request to python vector service and return response.
+ */
+router.post('/search/milvus', async (req, res) => {
+  const { imageBase64, topK } = req.body || {};
+  if (!imageBase64) {
+    return res.status(400).json({ error: 'imageBase64 required' });
+  }
+
+  const url = `${VECTOR_SERVICE_URL}/vector/search`;
+  try {
+    const resp = await axios.post(url, {
+      image_base64: imageBase64,
+      top_k: topK || 5
+    });
+    return res.json(resp.data);
+  } catch (err) {
+    console.error('[searchMilvus] error =>', err.message || err);
+    if (err.response) {
+      return res.status(err.response.status).json(err.response.data);
+    }
+    return res.status(500).json({ error: 'vector service error' });
+  }
+});
+
+module.exports = router;

--- a/express/server.js
+++ b/express/server.js
@@ -9,6 +9,7 @@ const paymentRoutes = require('./routes/paymentRoutes');
 const protectRouter = require('./routes/protect');
 const adminRouter   = require('./routes/admin');
 const authRouter    = require('./routes/authRoutes');
+const searchMilvusRouter = require('./routes/searchMilvus');
 
 const fs   = require('fs');
 const path = require('path');
@@ -44,6 +45,7 @@ app.get('/health', (req, res) => {
  | 4. 掛載各路由
  *──────────────────────────────────────────────*/
 app.use('/api',          paymentRoutes);
+app.use('/api',          searchMilvusRouter);
 app.use('/api/protect',  protectRouter);
 app.use('/admin',        adminRouter);
 app.use('/auth',         authRouter);


### PR DESCRIPTION
## Summary
- create `searchMilvus` router to forward vector search requests to the python service
- register the router in `server.js`

## Testing
- `npm run vision:test` *(fails: Cannot find module '@google-cloud/vision')*

------
https://chatgpt.com/codex/tasks/task_e_68466d4975f4832497f994d8b376af28