### PR TITLE
Add search report PDF route

### DIFF
--- a/express/routes/report.js
+++ b/express/routes/report.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const path = require('path');
+const router = express.Router();
+
+// service for generating PDF report
+const { generateSearchReport } = require('../services/pdf/pdfService');
+
+/**
+ * POST /api/report/search
+ * Accepts search result data and returns generated PDF path/URL.
+ */
+router.post('/report/search', async (req, res) => {
+  try {
+    const { results } = req.body;
+    if (!Array.isArray(results)) {
+      return res.status(400).json({ error: 'Invalid results' });
+    }
+
+    // generate PDF using provided search results
+    const pdfPath = await generateSearchReport(results);
+    const url = `/uploads/${path.basename(pdfPath)}`;
+
+    return res.json({ path: pdfPath, url });
+  } catch (err) {
+    console.error('[report/search error]', err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/express/server.js
+++ b/express/server.js
@@ -9,6 +9,7 @@ const paymentRoutes = require('./routes/paymentRoutes');
 const protectRouter = require('./routes/protect');
 const adminRouter   = require('./routes/admin');
 const authRouter    = require('./routes/authRoutes');
+const reportRouter  = require('./routes/report');
 
 const fs   = require('fs');
 const path = require('path');
@@ -44,6 +45,7 @@ app.get('/health', (req, res) => {
  | 4. 掛載各路由
  *──────────────────────────────────────────────*/
 app.use('/api',          paymentRoutes);
+app.use('/api',          reportRouter);
 app.use('/api/protect',  protectRouter);
 app.use('/admin',        adminRouter);
 app.use('/auth',         authRouter);


### PR DESCRIPTION
## Summary
- add POST `/api/report/search` route to generate PDF summary of search results
- expose `/api/report/search` via Express server

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68466d4a46148324986d234d42ef8b35