### PR TITLE
Add TinEye API integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example environment variables
+TINEYE_API_KEY=your_tineye_api_key_here

--- a/express/services/crawlers/tinEyeCrawler.js
+++ b/express/services/crawlers/tinEyeCrawler.js
@@ -1,52 +1,18 @@
 // express/services/crawlers/tinEyeCrawler.js
-const path = require('path');
-const { saveScreenshot, handleEngineError } = require('../../utils/screenshotUtil');
+const { searchByFile, extractLinks } = require('../tineyeApiService');
 
-async function searchTinEye(browser, imagePath){
+async function searchTinEye(_browser, imagePath){
   const engineName = 'tineye';
-  let page;
-  let resultScreenshot='';
-  let foundLinks=[];
-  const maxAttempts=3;
-
-  for(let attempt=1; attempt<=maxAttempts; attempt++){
-    try {
-      page = await browser.newPage();
-      await page.goto('https://tineye.com/', {
-        waitUntil:'domcontentloaded',
-        timeout:15000
-      });
-
-      const homeShot = path.join('uploads', `${engineName}_home_${Date.now()}.png`);
-      await saveScreenshot(page, homeShot);
-
-      const fileInputSel='input[type=file][name="image"]';
-      const fileInput = await page.waitForSelector(fileInputSel, { timeout:8000 });
-      await fileInput.uploadFile(imagePath);
-      await page.waitForTimeout(2000);
-
-      await page.waitForNavigation({ waitUntil:'domcontentloaded', timeout:15000 }).catch(()=>{});
-      await page.waitForTimeout(2000);
-
-      resultScreenshot = path.join('uploads', `${engineName}_results_${Date.now()}.png`);
-      await saveScreenshot(page, resultScreenshot);
-
-      let links = await page.$$eval('a', as=>as.map(a=>a.href));
-      links = links.filter(l => l && !l.includes('tineye.com'));
-      foundLinks = links.slice(0,5);
-
-      console.log(`[TinEye] found ${foundLinks.length} links at attempt #${attempt}`);
-      break;
-    } catch(err){
-      await handleEngineError(page, engineName, attempt, err);
-    } finally {
-      if(page) await page.close().catch(()=>{});
-    }
+  let foundLinks = [];
+  try {
+    const data = await searchByFile(imagePath);
+    foundLinks = extractLinks(data).slice(0,5);
+  } catch(err){
+    console.error('[TinEye API] error =>', err.message);
   }
-
   return {
     engine: engineName,
-    screenshotPath: resultScreenshot,
+    screenshotPath: '',
     links: foundLinks,
     success: foundLinks.length>0
   };

--- a/express/services/tineyeApiService.js
+++ b/express/services/tineyeApiService.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const axios = require('axios');
+const FormData = require('form-data');
+
+const API_URL = 'https://api.tineye.com/rest';
+const API_KEY = process.env.TINEYE_API_KEY;
+
+function ensureApiKey(){
+  if(!API_KEY){
+    throw new Error('TINEYE_API_KEY is not defined');
+  }
+}
+
+async function searchByUrl(imageUrl, options={}){
+  ensureApiKey();
+  const params = { image_url: imageUrl, ...options };
+  const { data } = await axios.get(`${API_URL}/search/`, {
+    params,
+    headers: { 'X-API-Key': API_KEY }
+  });
+  return data;
+}
+
+async function searchByFile(filePath, options={}){
+  ensureApiKey();
+  const form = new FormData();
+  form.append('image_upload', fs.createReadStream(filePath));
+  const query = new URLSearchParams(options).toString();
+  const { data } = await axios.post(`${API_URL}/search/?${query}`, form, {
+    headers: { ...form.getHeaders(), 'X-API-Key': API_KEY }
+  });
+  return data;
+}
+
+function extractLinks(apiResponse){
+  const links = [];
+  const matches = apiResponse?.results?.matches || [];
+  for(const m of matches){
+    if(Array.isArray(m.backlinks)){
+      for(const b of m.backlinks){
+        if(b.backlink) links.push(b.backlink);
+        else if(typeof b === 'string') links.push(b);
+      }
+    }
+  }
+  return Array.from(new Set(links));
+}
+
+module.exports = {
+  searchByUrl,
+  searchByFile,
+  extractLinks
+};

--- a/express/services/tineyeSearch.js
+++ b/express/services/tineyeSearch.js
@@ -1,65 +1,14 @@
-const fs = require('fs');
-const path = require('path');
+const { searchByFile, extractLinks } = require('./tineyeApiService');
 
-async function searchImageTinEye(browser, imagePath) {
+async function searchImageTinEye(_browser, imagePath) {
     const result = { success: false, engine: 'TinEye', links: [], error: null };
-    let page;
-    for (let attempt = 1; attempt <= 3; attempt++) {
-        try {
-            page = await browser.newPage();
-            await page.setViewport({ width: 1280, height: 800 });
-            await page.goto('https://tineye.com/', { waitUntil: 'domcontentloaded' });
-            // TinEye 首頁有拖拉上傳區和一個隱藏的文件選擇按鈕
-            const fileInputSelector = 'input[type=file][name="image"]';
-            await page.waitForSelector(fileInputSelector, { timeout: 5000 });
-            const fileInput = await page.$(fileInputSelector);
-            await fileInput.uploadFile(imagePath);
-            await fileInput.evaluate(input => {
-                const evt = new Event('change', { bubbles: true });
-                input.dispatchEvent(evt);
-            });
-            // 上傳後 TinEye 通常自動提交，導向結果頁（同窗口刷新）
-            // 等待結果文字或結果列表元素出現
-            await page.waitForTimeout(5000);  // 給幾秒讓TinEye處理上傳
-            // 等待結果計數或 "No results" 文本
-            await page.waitForFunction(() => {
-                const text = document.body.innerText;
-                return text.includes('results') || text.includes('TinEye has not found');
-            }, { timeout: 15000 });
-            
-            // 檢查是否為 "無結果"
-            const pageText = await page.evaluate(() => document.body.innerText);
-            if (pageText.includes('TinEye has not found') || pageText.toLowerCase().includes('no results')) {
-                // 無結果情況
-                result.links = [];
-            } else {
-                // 提取結果連結清單：TinEye 結果頁鏈結通常帶有 /result/ 路徑並target=_blank
-                const links = await page.$$eval('a[href^="http"]', anchors => 
-                    anchors.filter(a => a.href && !a.href.includes('tineye.com')).map(a => a.href)
-                );
-                result.links = links;
-            }
-            result.success = true;
-            // 截圖保存結果/無結果頁
-            await page.screenshot({ path: path.join(__dirname, `../logs/tineye_${result.links.length ? 'result' : 'noresult'}_${Date.now()}.png`) });
-            break;
-        } catch (err) {
-            result.error = err.message;
-            console.error(`TinEye 搜尋嘗試第 ${attempt} 次失敗:`, err);
-            if (page) await page.close().catch(e => {});
-            if (attempt === 3) {
-                if (page) {
-                    await page.screenshot({ path: path.join(__dirname, `../logs/tineye_error_${Date.now()}.png`) }).catch(e=>{});
-                }
-                throw new Error(`TinEye 圖片搜尋失敗: ${err.message}`);
-            }
-            await new Promise(res => setTimeout(res, 2000));
-            continue;
-        } finally {
-            if (page && !page.isClosed()) {
-                await page.close().catch(e => {});
-            }
-        }
+    try {
+        const data = await searchByFile(imagePath);
+        result.links = extractLinks(data);
+        result.success = result.links.length > 0;
+    } catch (err) {
+        result.error = err.message;
+        console.error('[TinEye API] search failed:', err.message);
     }
     return result;
 }


### PR DESCRIPTION
## Summary
- implement `tineyeApiService` using TinEye REST API
- switch TinEye search utilities and crawler to use API
- update protect route to call API service
- document `TINEYE_API_KEY` in `.env.example`

## Testing
- `npm run vision:test` *(fails: Cannot find module '@google-cloud/vision')*

------
https://chatgpt.com/codex/tasks/task_e_68466d933e0c832486c3f4a4d09c1ad0