### PR TITLE
Fix env password handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Example environment configuration
+
+# PostgreSQL database credentials
+POSTGRES_USER=suzoo
+POSTGRES_PASSWORD=
+POSTGRES_DB=suzoo
+POSTGRES_HOST=suzoo_postgres
+POSTGRES_PORT=5432
+
+# Add other variables as needed

--- a/fastapi/main.py
+++ b/fastapi/main.py
@@ -23,7 +23,9 @@ DB_HOST = os.getenv("POSTGRES_HOST", "suzoo_postgres")
 DB_PORT = os.getenv("POSTGRES_PORT", "5432")
 DB_NAME = os.getenv("POSTGRES_DB", "suzoo")
 DB_USER = os.getenv("POSTGRES_USER", "suzoo")
-DB_PASSWORD = os.getenv("POSTGRES_PASSWORD", "KaiShieldDbPass2023!")
+DB_PASSWORD = os.getenv("POSTGRES_PASSWORD")
+if not DB_PASSWORD:
+    raise RuntimeError("POSTGRES_PASSWORD environment variable is required")
 
 JWT_SECRET = os.getenv("JWT_SECRET")
 RAPIDAPI_KEY = os.getenv("RAPIDAPI_KEY")


### PR DESCRIPTION
## Summary
- enforce POSTGRES_PASSWORD env var
- add example env configuration

## Testing
- `python -m py_compile fastapi/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68466d96cda88324a43bcf28ec20aa58