### PR TITLE
Fix code fencing artifacts in Express server

### DIFF
--- a/express/routes/searchRoutes.js
+++ b/express/routes/searchRoutes.js
@@ -1,4 +1,3 @@
-```js
 /*************************************************************
  * express/routes/searchRoutes.js
  *
@@ -26,4 +25,3 @@ router.post('/search/tineye', async (req, res) => {
 });
 
 module.exports = router;
-```

--- a/express/server.js
+++ b/express/server.js
@@ -1,4 +1,3 @@
-```js
 require('dotenv').config();
 const express       = require('express');
 const cors          = require('cors');
@@ -213,4 +212,3 @@ const PORT = process.env.PORT || 3000;
 app.listen(PORT, '0.0.0.0', () => {
   console.log(`[Express] Running on port ${PORT}`);
 });
-```

--- a/express/services/tineyeService.js
+++ b/express/services/tineyeService.js
@@ -1,4 +1,3 @@
-```js
 require('dotenv').config();
 const axios = require('axios');
 
@@ -47,4 +46,3 @@ async function searchTinEyeApi(imageUrl) {
 }
 
 module.exports = { searchTinEyeApi };
-```

--- a/express/services/visionService.js
+++ b/express/services/visionService.js
@@ -1,4 +1,3 @@
-```js
 /**
  * express/services/visionService.js
  *
@@ -140,4 +139,3 @@ async function getVisionPageMatches(filePath, maxResults = 10) {
 module.exports = {
   getVisionPageMatches
 };
-```


### PR DESCRIPTION
## Summary
- remove stray ``` fences from Express files

## Testing
- `npm run vision:test` *(fails: Cannot find module '@google-cloud/vision')*

------
https://chatgpt.com/codex/tasks/task_e_684685ce660c8324a79ffc216ef2c662