### PR TITLE
Fix frontend container volume conflict

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,6 @@ services:
       - ./nginx/suzoo.conf:/etc/nginx/conf.d/suzoo_http.conf:ro
       - ./frontend/build:/usr/share/nginx/html:ro
       - /etc/letsencrypt:/etc/letsencrypt:ro
-      - uploads_data:/usr/share/nginx/html/uploads:ro
     command: ["/bin/sh", "-c", "rm -f /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"]
     networks:
       - suzoo_net


### PR DESCRIPTION
## Summary
- remove overlapping `/usr/share/nginx/html/uploads` volume from `suzoo_frontend`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6846bcd047b083248504bf6784772357