### PR TITLE
Document protect API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,19 @@ docker-compose up --build
 
 ```bash
 TINEYE_API_KEY=your_tineye_api_key
+```
+
+## Protect API Routes
+
+The Express service exposes endpoints under `/api/protect`.
+
+### `POST /api/protect/step1`
+
+- Upload a file and generate its protection certificate.
+- Returns information such as `fileId`, `fingerprint`, `ipfsHash` and `txHash`.
+
+### Step2 status
+
+There is currently **no** `/api/protect/step2` endpoint. The Step2 page in the
+UI simply reads the Step1 response from `localStorage` to display those
+details.


### PR DESCRIPTION
## Summary
- close the TinEye API example block
- add documentation for available /api/protect routes
- clarify that step2 has no backend route and UI reads localStorage data

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6846cc86f7d88324ba41b4f1e10c656e