### PR TITLE
Add protect step2 endpoint and frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,22 @@ docker-compose up --build
 
 ```bash
 TINEYE_API_KEY=your_tineye_api_key
+
+## Protect API Endpoints
+
+### POST `/api/protect/step2`
+
+在使用者完成 Step1 上傳後，可呼叫此端點進行後續伺服器處理。
+
+**參數**
+
+- `fileId` (number, required)：Step1 回傳的檔案 ID。
+
+**回應範例**
+
+```json
+{
+  "message": "Step2 處理完成",
+  "fileId": 123
+}
+```

--- a/express/package.json
+++ b/express/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "vision:test": "node ./tests/vision.test.js"
+    "vision:test": "node ./tests/vision.test.js",
+    "test": "jest"
   },
   "dependencies": {
     "@google-cloud/vision": "4.3.3",
@@ -33,5 +34,9 @@
     "sequelize": "^6.31.1",
     "sharp": "^0.32.1",
     "web3": "^1.10.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/express/routes/protect.js
+++ b/express/routes/protect.js
@@ -1187,7 +1187,32 @@ router.post('/step1', upload.single('file'), async(req,res)=>{
 });
 
 //===========================================================
-// [8] GET /protect/certificates/:fileId => 下載 PDF
+// [8] POST /protect/step2 => 處理 Step1 後續作業
+//===========================================================
+router.post('/step2', async (req, res) => {
+  try {
+    const { fileId } = req.body || {};
+    if (!fileId) {
+      return res.status(400).json({ error: 'MISSING_FILE_ID', message: '請提供 fileId' });
+    }
+
+    const fileRec = await File.findByPk(fileId);
+    if (!fileRec) {
+      return res.status(404).json({ error: 'FILE_NOT_FOUND', message: '無此 File ID' });
+    }
+
+    fileRec.status = 'uploaded';
+    await fileRec.save();
+
+    return res.json({ message: 'Step2 處理完成', fileId: fileRec.id });
+  } catch (e) {
+    console.error('[step2 error]', e);
+    return res.status(500).json({ error: 'STEP2_ERROR', detail: e.message });
+  }
+});
+
+//===========================================================
+// [9] GET /protect/certificates/:fileId => 下載 PDF
 //===========================================================
 router.get('/certificates/:fileId', async(req,res)=>{
   try {
@@ -1204,7 +1229,7 @@ router.get('/certificates/:fileId', async(req,res)=>{
 });
 
 //===========================================================
-// [9] GET /protect/scan/:fileId => 侵權掃描
+// [10] GET /protect/scan/:fileId => 侵權掃描
 //===========================================================
 router.get('/scan/:fileId', async(req,res)=>{
   try {
@@ -1355,7 +1380,7 @@ router.get('/scan/:fileId', async(req,res)=>{
 });
 
 //===========================================================
-// [10] GET /protect/scanReports/:fileId => 下載報告 PDF
+// [11] GET /protect/scanReports/:fileId => 下載報告 PDF
 //===========================================================
 router.get('/scanReports/:fileId', async(req,res)=>{
   try {

--- a/express/tests/step2.test.js
+++ b/express/tests/step2.test.js
@@ -1,0 +1,40 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../models', () => ({
+  File: {
+    findByPk: jest.fn()
+  },
+  User: {}
+}));
+
+const { File } = require('../models');
+const protectRouter = require('../routes/protect');
+
+const app = express();
+app.use(express.json());
+app.use('/api/protect', protectRouter);
+
+describe('POST /api/protect/step2', () => {
+  beforeEach(() => {
+    File.findByPk.mockReset();
+  });
+
+  test('missing fileId returns 400', async () => {
+    const res = await request(app).post('/api/protect/step2').send({});
+    expect(res.status).toBe(400);
+  });
+
+  test('non existent file returns 404', async () => {
+    File.findByPk.mockResolvedValue(null);
+    const res = await request(app).post('/api/protect/step2').send({ fileId: 1 });
+    expect(res.status).toBe(404);
+  });
+
+  test('valid fileId returns success', async () => {
+    File.findByPk.mockResolvedValue({ id: 2, save: jest.fn() });
+    const res = await request(app).post('/api/protect/step2').send({ fileId: 2 });
+    expect(res.status).toBe(200);
+    expect(res.body.fileId).toBe(2);
+  });
+});

--- a/frontend/src/pages/ProtectStep2.jsx
+++ b/frontend/src/pages/ProtectStep2.jsx
@@ -99,6 +99,7 @@ export default function ProtectStep2() {
   const [protectedUrl, setProtectedUrl] = useState('');
   const [loadingProtect, setLoadingProtect] = useState(false);
   const [error, setError] = useState('');
+  const [processing, setProcessing] = useState(true);
 
   useEffect(() => {
     // 讀取 Step1 的資料
@@ -110,6 +111,24 @@ export default function ProtectStep2() {
     }
     const data = JSON.parse(stored);
     setResult(data);
+
+    async function callStep2() {
+      try {
+        const resp = await fetch('/api/protect/step2', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ fileId: data.fileId })
+        });
+        const d = await resp.json().catch(() => ({}));
+        if (!resp.ok) throw new Error(d.error || `Error ${resp.status}`);
+      } catch (e) {
+        console.error('[step2]', e);
+        setError(e.message);
+      } finally {
+        setProcessing(false);
+      }
+    }
+    callStep2();
   }, [navigate]);
 
   if (!result) {
@@ -171,6 +190,8 @@ export default function ProtectStep2() {
     <PageWrapper>
       <Container>
         <Title>Step 2: 上傳完成 &amp; 產生證書</Title>
+        {processing && <p>伺服器處理中...</p>}
+        {error && !protectedUrl && <ErrorMsg>{error}</ErrorMsg>}
         <InfoBlock>
           <p><strong>File ID:</strong> {fileId}</p>
           <p><strong>Fingerprint (SHA-256):</strong> {fingerprint || 'N/A'}</p>


### PR DESCRIPTION
## Summary
- implement POST /api/protect/step2 in Express
- hook ProtectStep2 page to call new API
- document the step2 endpoint in README
- add Jest test for step2 endpoint

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846cc893d8c8324ba61f8cabc90b801