### PR TITLE
Fix Nginx http2 directive

### DIFF
--- a/frontend/suzoo.conf
+++ b/frontend/suzoo.conf
@@ -12,8 +12,9 @@ server {
 # HTTPS 服務 (主要站點)
 #######################################
 server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
 
     server_name suzookaizokuhunter.com www.suzookaizokuhunter.com;
 


### PR DESCRIPTION
## Summary
- update `frontend/suzoo.conf` to move `http2` out of the `listen` directive

## Testing
- `docker --version` *(fails: command not found)*
- `docker-compose --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846efea12f48324943eca60d95f5005