### PR TITLE
Configure FastAPI to use explicit Postgres env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,11 @@ services:
       dockerfile: Dockerfile
     environment:
       DATABASE_URL: ${DATABASE_URL}
+      POSTGRES_HOST: ${POSTGRES_HOST}
+      POSTGRES_PORT: ${POSTGRES_PORT}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     depends_on:
       - suzoo_postgres
     ports:


### PR DESCRIPTION
## Summary
- expose individual Postgres connection settings to the `suzoo_fastapi` service

## Testing
- `docker compose up -d --build suzoo_fastapi` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846f837e6008324bc812253bcf87211