### PR TITLE
Fix Milvus Minio address

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,7 +170,7 @@ services:
     command: ["milvus", "run", "standalone"]
     environment:
       ETCD_ENDPOINTS: "suzoo_etcd:2379"
-      MINIO_ADDRESS: "suzoo_minio:9000"
+      MINIO_ADDRESS: "http://suzoo_minio:9000"
       MINIO_ACCESS_KEY_ID: "admin"
       MINIO_SECRET_ACCESS_KEY: "admin123"
       MINIO_USE_SSL: "false"


### PR DESCRIPTION
## Summary
- update MINIO_ADDRESS for the Milvus service

## Testing
- `apt-get install -y docker.io`
- `dockerd` *(fails: permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6846f838e6008324af56c08abca4e5c9