### PR TITLE
Fix Nginx 403 by building React front-end

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,9 @@ services:
 
   suzoo_frontend:
     container_name: suzoo_frontend
-    image: nginx:alpine
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
     depends_on:
       - suzoo_express
       - suzoo_fastapi
@@ -79,7 +81,6 @@ services:
     volumes:
       - ./frontend/suzoo.conf:/etc/nginx/conf.d/suzoo_https.conf:ro
       - ./nginx/suzoo.conf:/etc/nginx/conf.d/suzoo_http.conf:ro
-      - ./frontend/build:/usr/share/nginx/html:ro
       - /etc/letsencrypt:/etc/letsencrypt:ro
     command: ["/bin/sh", "-c", "rm -f /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"]
     networks:


### PR DESCRIPTION
## Summary
- build the React front-end during Docker image creation instead of mounting build artifacts

## Testing
- `docker compose config` *(fails: `docker: command not found`)*
- `npm test` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68470729cd8883249126592a28860e8f