### PR TITLE
Fix multi-stage frontend build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
 # Ignore dependencies and build output to speed up Docker build
 node_modules
 build
+dist
+.git
+Dockerfile
+*.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,9 +69,11 @@ services:
 
   suzoo_frontend:
     container_name: suzoo_frontend
-    image: suzookaizokuhunter-frontend:latest
     build:
       context: ./frontend
+      args:
+        REACT_APP_API_URL: ${REACT_APP_API_URL:-https://api.suzookaizokuhunter.com}
+    image: suzookaizokuhunter-frontend
     depends_on:
       - suzoo_express
       - suzoo_fastapi

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,3 +1,35 @@
+# syntax=docker/dockerfile:1
+########## 1️⃣ Build Stage ###############################################
+FROM node:18-alpine AS builder
+
+WORKDIR /app
+
+# 先複製 package* 以便快取 install 步驟
+COPY package.json package-lock.json ./
+RUN npm ci --legacy-peer-deps
+
+# 再複製其餘原始碼
+COPY . .
+
+# 將後端 API 位址在建置期注入；預設為 dev 值
+ARG REACT_APP_API_URL=http://localhost:3000
+ENV REACT_APP_API_URL=${REACT_APP_API_URL}
+
+# 產生正式版靜態檔
+RUN npm run build
+
+########## 2️⃣ Production Stage ##########################################
 FROM nginx:alpine
-COPY build/ /usr/share/nginx/html/
-# COPY nginx/conf.d/ /etc/nginx/conf.d/   # if custom config is used
+
+# 將 React build 產物放進 Nginx 預設靜態目錄
+COPY --from=builder /app/build /usr/share/nginx/html
+
+# 若要自訂 nginx conf（建議），請取消下一行註解並提供檔案
+# COPY nginx/default.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=5s \
+  CMD wget -qO- http://localhost/ || exit 1
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx/default.conf
+++ b/frontend/nginx/default.conf
@@ -1,0 +1,16 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+
+    location / {
+        try_files $uri /index.html;
+    }
+
+    # 將 API Proxy（若前端直接呼叫 /api）導向後端 container
+    location /api/ {
+        proxy_pass http://suzoo_express:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}


### PR DESCRIPTION
## Summary
- reinstate multi-stage build in `frontend/Dockerfile`
- add optional nginx config for frontend builds
- expand `.dockerignore` for Docker context hygiene
- pass REACT_APP_API_URL via build args in docker-compose

## Testing
- `npm test` *(fails: No tests found)*
- `CI=true npm test` *(fails: No tests found)*
- ❌ `docker compose build` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847c182cf4c8324bbd56f1ba6b46b47