### PR TITLE
Add global XHR URL validation

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { installXhrOpenValidation } from './setupXhrValidation';
+
+// Install global validation for XMLHttpRequest.open calls.
+installXhrOpenValidation();
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/frontend/src/setupXhrValidation.js
+++ b/frontend/src/setupXhrValidation.js
@@ -1,0 +1,16 @@
+export function installXhrOpenValidation() {
+  if (typeof XMLHttpRequest === 'undefined') {
+    return;
+  }
+
+  const originalOpen = XMLHttpRequest.prototype.open;
+
+  XMLHttpRequest.prototype.open = function(method, url, ...args) {
+    if (typeof url !== 'string' || !/^https?:\/\//i.test(url)) {
+      throw new Error(
+        `XMLHttpRequest.open: invalid URL "${url}". Expected URL starting with http:// or https://.`
+      );
+    }
+    return originalOpen.call(this, method, url, ...args);
+  };
+}


### PR DESCRIPTION
## Summary
- enforce URL validation by intercepting `XMLHttpRequest.open`
- enable the interceptor in the React entrypoint

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6847f675c0d88324abd08abdd3cfb734