### PR TITLE
Add reverse image search test script

### DIFF
--- a/test-reverse-image.js
+++ b/test-reverse-image.js
@@ -1,0 +1,28 @@
+require('dotenv').config();
+const vision = require('@google-cloud/vision');
+const axios = require('axios');
+
+async function main() {
+  const image = process.argv[2];
+  if (!image) {
+    console.error('Usage: node test-reverse-image.js <IMAGE_URL_OR_PATH>');
+    process.exit(1);
+  }
+
+  try {
+    const client = new vision.ImageAnnotatorClient();
+    const [visionResult] = await client.labelDetection(image);
+    console.log('Google Vision result:', JSON.stringify(visionResult.labelAnnotations, null, 2));
+
+    const tineyeKey = process.env.TINEYE_API_KEY;
+    if (!tineyeKey) throw new Error('TINEYE_API_KEY is not set');
+    const tineyeRes = await axios.get('https://api.tineye.com/rest/search/', {
+      params: { api_key: tineyeKey, url: image }
+    });
+    console.log('TinEye result:', JSON.stringify(tineyeRes.data, null, 2));
+  } catch (err) {
+    console.error('Error:', err.stack || err);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add `test-reverse-image.js` to demo Google Vision and TinEye APIs

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684809608a188324a7574e3dee87182a