### PR TITLE
Add VISION_MAX_RESULTS env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,6 +112,7 @@ VECTOR_SERVICE_URL=http://suzoo_python_vector:8000
 # Google Cloud Vision
 ########################################
 GOOGLE_APPLICATION_CREDENTIALS=./credentials/gcp-vision.json
+VISION_MAX_RESULTS=50
 
 ########################################
 # TinEye 反向圖搜尋 API

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ RAPIDAPI_KEY=your_rapidapi_key
 AWS_ACCESS_KEY=your_aws_access_key
 AWS_SECRET_KEY=your_aws_secret_key
 GOOGLE_APPLICATION_CREDENTIALS=./credentials/gcp-vision.json
+VISION_MAX_RESULTS=50
 TINEYE_API_KEY=your_tineye_api_key
 ```
 
@@ -35,6 +36,8 @@ docker-compose up --build
 
    ```bash
    GOOGLE_APPLICATION_CREDENTIALS=/app/credentials/gcp-vision.json
+   # 每次 Google Vision 搜尋回傳的網址數量上限 (預設 50)
+   VISION_MAX_RESULTS=50
    ```
 
    `docker-compose.yml` 會自動將 `./credentials` 掛載到 `/app/credentials`（唯讀）。

--- a/express/routes/infringement.js
+++ b/express/routes/infringement.js
@@ -16,6 +16,7 @@ const axios = require('axios');
 const { detectInfringement } = require('../services/infringementService');
 const tinEyeApi = require('../services/tineyeApiService');
 const { getVisionPageMatches } = require('../services/visionService');
+const VISION_MAX_RESULTS = parseInt(process.env.VISION_MAX_RESULTS, 10) || 50;
 // const { sendDmcaNotice } = require('../services/dmcaService');
 
 const JWT_SECRET = process.env.JWT_SECRET || 'KaiKaiShieldSecret';
@@ -116,7 +117,7 @@ router.post('/scan', authMiddleware, ensureVisionCredentials, async (req, res) =
     // Google Vision search
     let visionRes = { success: false, links: [] };
     try {
-      const urls = await getVisionPageMatches(localFile, 10);
+      const urls = await getVisionPageMatches(localFile, VISION_MAX_RESULTS);
       visionRes = { success: urls.length > 0, links: urls };
     } catch (err) {
       console.error('[Google Vision error]', err);

--- a/express/routes/protect.js
+++ b/express/routes/protect.js
@@ -27,6 +27,7 @@ if(ffmpegPath) {
 // ========== Google Vision API ==========
 // 同一呼叫 services/visionService.js，避免重複定義
 const { getVisionPageMatches } = require('../services/visionService');
+const VISION_MAX_RESULTS = parseInt(process.env.VISION_MAX_RESULTS, 10) || 50;
 
 // ========== Models ==========
 const { User, File } = require('../models');
@@ -805,7 +806,7 @@ async function doSearchEngines(localFilePath, aggregatorFirst=true, aggregatorIm
 
   // ★ Vision
   try {
-    const visionUrls = await getVisionPageMatches(localFilePath, 10);
+    const visionUrls = await getVisionPageMatches(localFilePath, VISION_MAX_RESULTS);
     if (visionUrls.length) {
       ret.vision = { links: visionUrls, success: true };
     }

--- a/express/services/visionService.js
+++ b/express/services/visionService.js
@@ -107,10 +107,12 @@ function isValidLink(u) {
  * 取得 Google Vision WebDetection 結果網址清單
  * - 合併 fullMatchingImages / partialMatchingImages / pagesWithMatchingImages
  * @param {string} filePath - 本機圖檔路徑
- * @param {number} [maxResults=10]
+ * @param {number} [maxResults] - 回傳數量上限 (預設由環境變數 VISION_MAX_RESULTS 決定，預設 50)
  * @returns {Promise<string[]>}
  */
-async function getVisionPageMatches(filePath, maxResults = 10) {
+const DEFAULT_MAX_RESULTS = parseInt(process.env.VISION_MAX_RESULTS, 10) || 50;
+
+async function getVisionPageMatches(filePath, maxResults = DEFAULT_MAX_RESULTS) {
   if (!fs.existsSync(filePath)) {
     throw new Error('FILE_NOT_FOUND: ' + filePath);
   }

--- a/services/visionService.js
+++ b/services/visionService.js
@@ -34,10 +34,12 @@ const client = new vision.ImageAnnotatorClient({ keyFilename: KEY_FILE });
 /**
  * 透過 Google Vision WebDetection 取得「網頁上出現此圖片」的網址
  * @param  {string} imagePath - 本機圖片路徑
- * @param  {number} maxResults (預設 10)
+ * @param  {number} maxResults (預設由環境變數 VISION_MAX_RESULTS 決定，預設 50)
  * @return {Promise<string[]>} 只回傳有效 http/https URL 陣列
  */
-async function getVisionPageMatches(imagePath, maxResults = 10) {
+const DEFAULT_MAX_RESULTS = parseInt(process.env.VISION_MAX_RESULTS, 10) || 50;
+
+async function getVisionPageMatches(imagePath, maxResults = DEFAULT_MAX_RESULTS) {
   const buffer = await fs.promises.readFile(imagePath);
 
   /** 呼叫 annotateImage – 僅啟用 WebDetection ，限制 maxResults */


### PR DESCRIPTION
## Summary
- allow configuring max Google Vision results with `VISION_MAX_RESULTS`
- default services to use new env variable
- pass `VISION_MAX_RESULTS` in protect and infringement routes
- document new variable in README and `.env.example`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481a58b7848324b4e1326b66c4c05d