### PR TITLE
Use ENGINE_MAX_LINKS constant for engine results

### DIFF
--- a/express/googleRecverseImage.js
+++ b/express/googleRecverseImage.js
@@ -16,6 +16,8 @@
 const puppeteer = require('puppeteer');
 const path = require('path');
 
+const ENGINE_MAX_LINKS = parseInt(process.env.ENGINE_MAX_LINKS, 10) || 50;
+
 (async () => {
   // 1) 解析命令列參數 => 圖片路徑
   const imagePath = process.argv[2];
@@ -59,7 +61,7 @@ const path = require('path');
     const resultsSelector = 'div.g a';
     await page.waitForSelector(resultsSelector, { timeout: 15000 });
     const links = await page.$$eval(resultsSelector, (anchors) =>
-      anchors.slice(0, 5).map((a) => a.href)
+      anchors.slice(0, ENGINE_MAX_LINKS).map((a) => a.href)
     );
 
     console.log('【以圖搜圖】前 5 個搜尋結果連結：');

--- a/express/routes/infringement.js
+++ b/express/routes/infringement.js
@@ -16,6 +16,7 @@ const axios = require('axios');
 const { detectInfringement } = require('../services/infringementService');
 const tinEyeApi = require('../services/tineyeApiService');
 const { getVisionPageMatches } = require('../services/visionService');
+const ENGINE_MAX_LINKS = parseInt(process.env.ENGINE_MAX_LINKS, 10) || 50;
 // const { sendDmcaNotice } = require('../services/dmcaService');
 
 const JWT_SECRET = process.env.JWT_SECRET || 'KaiKaiShieldSecret';
@@ -107,7 +108,7 @@ router.post('/scan', authMiddleware, ensureVisionCredentials, async (req, res) =
     try {
       const data = await tinEyeApi.searchByFile(localFile);
       const links = tinEyeApi.extractLinks(data);
-      tineyeRes = { success: links.length > 0, links: links.slice(0, 5) };
+      tineyeRes = { success: links.length > 0, links: links.slice(0, ENGINE_MAX_LINKS) };
     } catch (err) {
       console.error('[TinEye API error]', err);
       tineyeRes = { success: false, message: err.message };

--- a/express/routes/protect.js
+++ b/express/routes/protect.js
@@ -41,6 +41,8 @@ const { searchImageByVector } = require('../utils/vectorSearch');
 const { generateScanPDFWithMatches } = require('../services/pdfService');
 const tinEyeApi = require('../services/tineyeApiService');
 
+const ENGINE_MAX_LINKS = parseInt(process.env.ENGINE_MAX_LINKS, 10) || 50;
+
 // ** (重點) 新增：引用 flickerService.js **
 const { flickerEncodeAdvanced } = require('../services/flickerService');
 
@@ -577,7 +579,7 @@ async function aggregatorSearchGinifab(browser, localImagePath, publicImageUrl) 
         // ★過濾無效連結
         hrefs = hrefs.filter(isValidLink);
 
-        ret[eng.key].links= hrefs.slice(0,5);
+        ret[eng.key].links= hrefs.slice(0, ENGINE_MAX_LINKS);
         ret[eng.key].success= ret[eng.key].links.length>0;
         await popup.close();
       } catch(eSub){
@@ -634,7 +636,7 @@ async function directSearchBing(browser, imagePath){
       let hrefs= await page.$$eval('a', as=> as.map(a=> a.href || ''));
       // 過濾自身 + 無效
       hrefs= hrefs.filter(h=> h && !h.includes('bing.com')).filter(isValidLink);
-      ret.links= [...new Set(hrefs)].slice(0,5);
+      ret.links= [...new Set(hrefs)].slice(0, ENGINE_MAX_LINKS);
       ret.success= ret.links.length>0;
     }
 
@@ -656,7 +658,7 @@ async function directSearchTinEye(_browser, imagePath){
   try {
     const data = await tinEyeApi.searchByFile(imagePath);
     const links = tinEyeApi.extractLinks(data);
-    ret.links = links.slice(0,5);
+    ret.links = links.slice(0, ENGINE_MAX_LINKS);
     ret.success = ret.links.length>0;
   } catch(e){
     console.error('[directSearchTinEye] API fail =>', e.message);
@@ -717,7 +719,7 @@ async function directSearchBaidu(browser, imagePath){
 
     let hrefs= await page.$$eval('a', as=> as.map(a=> a.href || ''));
     hrefs= hrefs.filter(h=> h && !h.includes('baidu.com')).filter(isValidLink);
-    ret.links= [...new Set(hrefs)].slice(0,5);
+    ret.links= [...new Set(hrefs)].slice(0, ENGINE_MAX_LINKS);
     ret.success= ret.links.length>0;
 
   } catch(e){

--- a/express/services/crawlers/baiduCrawler.js
+++ b/express/services/crawlers/baiduCrawler.js
@@ -2,6 +2,8 @@
 const path = require('path');
 const { saveScreenshot, handleEngineError } = require('../../utils/screenshotUtil');
 
+const ENGINE_MAX_LINKS = parseInt(process.env.ENGINE_MAX_LINKS, 10) || 50;
+
 async function searchBaidu(browser, imagePath) {
   const engineName='baidu';
   let page;
@@ -39,7 +41,7 @@ async function searchBaidu(browser, imagePath) {
 
       let links=await page.$$eval('a', as=>as.map(a=>a.href));
       links=links.filter(l => l && !l.includes('baidu.com'));
-      foundLinks=links.slice(0,5);
+      foundLinks=links.slice(0, ENGINE_MAX_LINKS);
 
       console.log(`[Baidu] found ${foundLinks.length} links at attempt #${attempt}`);
       break;

--- a/express/services/crawlers/bingCrawler.js
+++ b/express/services/crawlers/bingCrawler.js
@@ -2,6 +2,8 @@
 const path = require('path');
 const { saveScreenshot, handleEngineError } = require('../../utils/screenshotUtil');
 
+const ENGINE_MAX_LINKS = parseInt(process.env.ENGINE_MAX_LINKS, 10) || 50;
+
 async function searchBing(browser, imagePath) {
   const engineName = 'bing';
   let page;
@@ -47,7 +49,7 @@ async function searchBing(browser, imagePath) {
       // 擷取外部連結
       let links = await page.$$eval('a', as=>as.map(a=>a.href));
       links = links.filter(l => l && !l.includes('bing.com'));
-      foundLinks = links.slice(0,5);
+      foundLinks = links.slice(0, ENGINE_MAX_LINKS);
 
       console.log(`[Bing] found ${foundLinks.length} links at attempt #${attempt}`);
       break;

--- a/express/services/crawlers/ginifabCrawler.js
+++ b/express/services/crawlers/ginifabCrawler.js
@@ -2,6 +2,8 @@
 const path = require('path');
 const { saveScreenshot, handleEngineError } = require('../../utils/screenshotUtil');
 
+const ENGINE_MAX_LINKS = parseInt(process.env.ENGINE_MAX_LINKS, 10) || 50;
+
 /**
  * 透過 Ginifab Aggregator, 輸入 imageUrl(公開連結)
  * 順序點擊「微軟必應 / 錫眼睛 / 百度」
@@ -72,7 +74,7 @@ async function searchGinifab(browser, imageUrl) {
             !h.includes('tineye.com') &&
             !h.includes('baidu.com')
           );
-          const top5=hrefs.slice(0,5);
+          const top5=hrefs.slice(0, ENGINE_MAX_LINKS);
 
           results[eng.name].success= top5.length>0;
           results[eng.name].links= top5;

--- a/express/services/crawlers/tinEyeCrawler.js
+++ b/express/services/crawlers/tinEyeCrawler.js
@@ -1,12 +1,14 @@
 // express/services/crawlers/tinEyeCrawler.js
 const { searchByFile, extractLinks } = require('../tineyeApiService');
 
+const ENGINE_MAX_LINKS = parseInt(process.env.ENGINE_MAX_LINKS, 10) || 50;
+
 async function searchTinEye(_browser, imagePath){
   const engineName = 'tineye';
   let foundLinks = [];
   try {
     const data = await searchByFile(imagePath);
-    foundLinks = extractLinks(data).slice(0,5);
+    foundLinks = extractLinks(data).slice(0, ENGINE_MAX_LINKS);
   } catch(err){
     console.error('[TinEye API] error =>', err.message);
   }

--- a/express/services/ginifabEngine.js
+++ b/express/services/ginifabEngine.js
@@ -7,6 +7,8 @@ puppeteer.use(StealthPlugin());
 const fs = require('fs');
 const path = require('path');
 
+const ENGINE_MAX_LINKS = parseInt(process.env.ENGINE_MAX_LINKS, 10) || 50;
+
 // ============== fallback 直連 Bing/TinEye/Baidu ==============
 async function fallbackDirectEngines(imagePath) {
   const results = {
@@ -36,7 +38,7 @@ async function fallbackDirectEngines(imagePath) {
 
         let links = await page.$$eval('a', as=> as.map(a=> a.href));
         links = links.filter(x=> x && !x.includes('bing.com'));
-        results.bing.push(...links.slice(0,5));
+        results.bing.push(...links.slice(0, ENGINE_MAX_LINKS));
       }
       await page.close();
     } catch(e) {
@@ -57,7 +59,7 @@ async function fallbackDirectEngines(imagePath) {
 
         let links = await page.$$eval('a', as=> as.map(a=> a.href));
         links = links.filter(x=> x && !x.includes('tineye.com'));
-        results.tineye.push(...links.slice(0,5));
+        results.tineye.push(...links.slice(0, ENGINE_MAX_LINKS));
       }
       await page.close();
     } catch(e) {
@@ -77,7 +79,7 @@ async function fallbackDirectEngines(imagePath) {
 
         let links = await page.$$eval('a', as=> as.map(a=> a.href));
         links = links.filter(x=> x && !x.includes('baidu.com'));
-        results.baidu.push(...links.slice(0,5));
+        results.baidu.push(...links.slice(0, ENGINE_MAX_LINKS));
       }
       await page.close();
     } catch(e) {
@@ -270,7 +272,7 @@ async function aggregatorSearchGinifab(localFilePath, aggregatorImageUrl) {
           return true;
         });
         // 只取前 5
-        result[eng.key].links = hrefs.slice(0,5);
+        result[eng.key].links = hrefs.slice(0, ENGINE_MAX_LINKS);
 
         await popup.close().catch(()=>{});
       } catch(eEng){

--- a/express/services/tineyeSearch.js
+++ b/express/services/tineyeSearch.js
@@ -1,10 +1,12 @@
 const { searchByFile, extractLinks } = require('./tineyeApiService');
 
+const ENGINE_MAX_LINKS = parseInt(process.env.ENGINE_MAX_LINKS, 10) || 50;
+
 async function searchImageTinEye(_browser, imagePath) {
     const result = { success: false, engine: 'TinEye', links: [], error: null };
     try {
         const data = await searchByFile(imagePath);
-        result.links = extractLinks(data);
+        result.links = extractLinks(data).slice(0, ENGINE_MAX_LINKS);
         result.success = result.links.length > 0;
     } catch (err) {
         result.error = err.message;

--- a/express/utils/aggregatorSearchGinifab.js
+++ b/express/utils/aggregatorSearchGinifab.js
@@ -23,6 +23,8 @@
 const path = require('path');
 const fs   = require('fs');
 
+const ENGINE_MAX_LINKS = parseInt(process.env.ENGINE_MAX_LINKS, 10) || 50;
+
 // selectors used to detect file upload inputs and url fields. additional
 // patterns are included so minor markup changes on ginifab won't break the flow
 const FILE_INPUT_SELECTOR = 'input[type=file], input[type="file"], input[name*=file], input[id*=file]';
@@ -276,7 +278,7 @@ async function aggregatorSearchGinifab(browser, localImagePath, publicImageUrl) 
           !h.includes('tineye.com') &&
           !h.includes('baidu.com')
         );
-        ret[eng.key].links = [...new Set(hrefs)].slice(0, 5);
+        ret[eng.key].links = [...new Set(hrefs)].slice(0, ENGINE_MAX_LINKS);
         ret[eng.key].success = ret[eng.key].links.length > 0;
 
         await popupPage.close();


### PR DESCRIPTION
## Summary
- add `ENGINE_MAX_LINKS` constant (default 50) across search routes and services
- slice engine links using this constant instead of hardcoded values

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481a59db3483248284c130aaf2fa0b