### PR TITLE
Add fallback login field

### DIFF
--- a/express/routes/authRoutes.js
+++ b/express/routes/authRoutes.js
@@ -19,7 +19,8 @@ const JWT_SECRET = process.env.JWT_SECRET || 'SomeSuperSecretKey';
  */
 router.post('/login', async (req, res) => {
   try {
-    const { identifier, password } = req.body;
+    const identifier = req.body.identifier || req.body.account;
+    const { password } = req.body;
     if (!identifier || !password) {
       return res.status(400).json({ message: '請輸入帳號與密碼' });
     }

--- a/express/server.js
+++ b/express/server.js
@@ -26,6 +26,8 @@ const infringementRouter = require('./routes/infringement');     // 侵權相關
  *───────────────────────────────────*/
 app.use(cors());
 app.use(express.json());
+// Allow parsing of application/x-www-form-urlencoded bodies
+app.use(express.urlencoded({ extended: true }));
 
 /*───────────────────────────────────  
  | 2. uploads 對外靜態目錄  


### PR DESCRIPTION
## Summary
- support `account` as an alias for `identifier` in login route
- parse URL‑encoded bodies

## Testing
- `npm --prefix express test --silent` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684941974a248324b7fbe23c2e53f556