### PR TITLE
Add fallback login field

### DIFF
--- a/ai_service/Dockerfile
+++ b/ai_service/Dockerfile
@@ -1,13 +1,15 @@
-FROM python:3.9
+FROM pytorch/pytorch:1.13.1-cuda11.6-cudnn8-runtime
 
 # 安裝必要套件 (含 opencv)
-RUN apt-get update && apt-get install -y libgl1-mesa-glx
+RUN apt-get update && apt-get install -y libgl1-mesa-glx && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
 # 複製需求檔
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt gunicorn
+# Skip installing torch/torchvision (already included in base image)
+RUN grep -v '^torch' requirements.txt | grep -v '^torchvision' > /tmp/reqs.txt \
+    && pip install --no-cache-dir -r /tmp/reqs.txt gunicorn
 
 # 複製程式碼
 COPY . /app

--- a/express/routes/authRoutes.js
+++ b/express/routes/authRoutes.js
@@ -19,7 +19,8 @@ const JWT_SECRET = process.env.JWT_SECRET || 'SomeSuperSecretKey';
  */
 router.post('/login', async (req, res) => {
   try {
-    const { identifier, password } = req.body;
+    const identifier = req.body.identifier || req.body.account;
+    const { password } = req.body;
     if (!identifier || !password) {
       return res.status(400).json({ message: '請輸入帳號與密碼' });
     }

--- a/express/server.js
+++ b/express/server.js
@@ -26,6 +26,8 @@ const infringementRouter = require('./routes/infringement');     // 侵權相關
  *───────────────────────────────────*/
 app.use(cors());
 app.use(express.json());
+// Allow parsing of application/x-www-form-urlencoded bodies
+app.use(express.urlencoded({ extended: true }));
 
 /*───────────────────────────────────  
  | 2. uploads 對外靜態目錄  

--- a/python_crawlers/Dockerfile
+++ b/python_crawlers/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM pytorch/pytorch:1.13.1-cuda11.6-cudnn8-runtime
 
 WORKDIR /app
 
@@ -6,7 +6,9 @@ RUN apt-get update && apt-get install -y ffmpeg && rm -rf /var/lib/apt/lists/*
 
 # 複製需求檔
 COPY requirements.txt .
-RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
+# Skip installing torch/torchvision (already included in base image)
+RUN grep -v '^torch' requirements.txt | grep -v '^torchvision' > /tmp/reqs.txt \
+    && pip install --no-cache-dir -r /tmp/reqs.txt
 
 # 複製所有程式碼
 COPY . /app/

--- a/python_crawlers/requirements.txt
+++ b/python_crawlers/requirements.txt
@@ -2,12 +2,12 @@ celery
 requests
 beautifulsoup4
 pymilvus
-torch
+torch==1.13.1
 transformers
 pillow
 sentence_transformers
 ffmpeg-python
 opencv-python
 open_clip_torch
-torchvision
+torchvision==0.14.1
 pytube


### PR DESCRIPTION
## Summary
- support `account` as an alias for `identifier` in login route
- parse URL‑encoded bodies
- use PyTorch runtime image to avoid heavy installs
- reuse same runtime for AI service and crawler

## Testing
- `npm --prefix express test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684941974a248324b7fbe23c2e53f556