### PR TITLE
Refine vision and TinEye services

### DIFF
--- a/.env
+++ b/.env
@@ -116,4 +116,4 @@ GOOGLE_APPLICATION_CREDENTIALS=./credentials/gcp-vision.json
 ########################################
 # TinEye 反向圖搜尋 API (最關鍵)
 ########################################
-TINEYE_API_KEY="29Qtdgo7xo_ec9_cNDh^PhOcXKc,aaHYiVgXIYhy"
+TINEYE_API_KEY=29Qtdgo7xo_ec9_cNDh^PhOcXKc,aaHYiVgXIYhy

--- a/express/routes/infringement.js
+++ b/express/routes/infringement.js
@@ -117,7 +117,7 @@ router.post('/scan', authMiddleware, ensureVisionCredentials, async (req, res) =
     // TinEye search
     let tineyeRes = { success: false, links: [] };
     try {
-      const data = await tinEyeApi.searchByFile(localFile);
+      const data = await tinEyeApi.searchByFile(localFile, { limit: ENGINE_MAX_LINKS });
       const links = tinEyeApi.extractLinks(data);
       tineyeRes = { success: links.length > 0, links: links.slice(0, ENGINE_MAX_LINKS) };
     } catch (err) {

--- a/express/services/tineyeApiService.js
+++ b/express/services/tineyeApiService.js
@@ -4,55 +4,50 @@ const FormData = require('form-data');
 
 const API_URL = 'https://api.tineye.com/rest';
 const API_KEY = process.env.TINEYE_API_KEY;
+if (!API_KEY) throw new Error('必须定义 TINEYE_API_KEY');
 
-if (!API_KEY) {
-  // Fail fast during service startup if API key missing
-  throw new Error('TINEYE_API_KEY is not defined');
-}
-
-function ensureApiKey(){
-  if(!API_KEY){
-    throw new Error('TINEYE_API_KEY is not defined');
-  }
-}
-
-async function searchByUrl(imageUrl, options={}){
-  ensureApiKey();
-  const params = { image_url: imageUrl, ...options };
-  const { data } = await axios.get(`${API_URL}/search/`, {
-    params,
-    headers: { 'X-API-Key': API_KEY }
+async function searchByUrl(imageUrl, options = {}) {
+  const resp = await axios.get('https://api.tineye.com/rest/search/', {
+    params: { image_url: imageUrl, ...options },
+    headers: { 'X-API-Key': API_KEY },
+    validateStatus: () => true
   });
-  return data;
+  if (resp.status !== 200) throw new Error(`TinEye 搜索失败：${resp.status}`);
+  return resp.data;
 }
 
-async function searchByFile(filePath, options={}){
-  ensureApiKey();
+async function searchByFile(filePath, options = {}) {
   const form = new FormData();
   form.append('image_upload', fs.createReadStream(filePath));
-  const query = new URLSearchParams(options).toString();
-  const { data } = await axios.post(`${API_URL}/search/?${query}`, form, {
-    headers: { ...form.getHeaders(), 'X-API-Key': API_KEY }
-  });
-  return data;
+  const resp = await axios.post(
+    `https://api.tineye.com/rest/search/?${new URLSearchParams(options).toString()}`,
+    form,
+    {
+      headers: { ...form.getHeaders(), 'X-API-Key': API_KEY },
+      maxContentLength: Infinity,
+      maxBodyLength: Infinity,
+      validateStatus: () => true
+    }
+  );
+  if (resp.status !== 200) throw new Error(`TinEye 搜索失败：${resp.status}`);
+  return resp.data;
 }
 
-function extractLinks(apiResponse){
+function extractLinks(apiResponse) {
+  const matches = apiResponse.results?.matches || [];
   const links = [];
-  const matches = apiResponse?.results?.matches || [];
-  for(const m of matches){
-    if(Array.isArray(m.backlinks)){
-      for(const b of m.backlinks){
-        if(b.backlink) links.push(b.backlink);
-        else if(typeof b === 'string') links.push(b);
+  for (const m of matches) {
+    if (Array.isArray(m.backlinks)) {
+      for (const b of m.backlinks) {
+        if (typeof b === 'string') links.push(b);
+        else if (b.backlink) links.push(b.backlink);
+        else if (b.url) links.push(b.url);
       }
+    } else if (m.backlink) {
+      links.push(m.backlink);
     }
   }
-  return Array.from(new Set(links));
+  return [...new Set(links)];
 }
 
-module.exports = {
-  searchByUrl,
-  searchByFile,
-  extractLinks
-};
+module.exports = { searchByUrl, searchByFile, extractLinks };

--- a/express/services/visionService.js
+++ b/express/services/visionService.js
@@ -1,154 +1,50 @@
-/**
- * express/services/visionService.js
- *
- * 單一責任：封裝 Google Cloud Vision WebDetection。
- * - 自動偵測 GOOGLE_APPLICATION_CREDENTIALS，否則預設讀取 ../../credentials/gcp-vision.json
- * - 超過 8 MB 圖片上傳限制前，先壓縮 (sharp)
- * - 預先做指紋雜湊和 LRU 快取，避免重複扣費
- * - 僅回傳有效 http/https 網址
- */
+const fs = require('fs');
+const sharp = require('sharp');
+const vision = require('@google-cloud/vision');
 
-const fs      = require('fs');
-const path    = require('path');
-const crypto  = require('crypto');
-const sharp   = require('sharp');
-const vision  = require('@google-cloud/vision');
-
-const DEFAULT_KEY_FILE    = '/app/credentials/gcp-vision.json';
-const MAX_VISION_SIZE     = 8 * 1024 * 1024;  // Vision 上限 8 MB
-const COMPRESS_THRESHOLD  = 7 * 1024 * 1024;  // >7 MB 就壓縮
-const LRU_CAPACITY        = 100;             // 最多快取 100 筆
-
-// --- Vision client ---
-let visionClient;
-function getClient() {
-  if (!visionClient) {
-    const keyFile = process.env.GOOGLE_APPLICATION_CREDENTIALS || DEFAULT_KEY_FILE;
-    console.log(`[visionService] using credential file: ${keyFile}`);
-    if (!fs.existsSync(keyFile)) {
-      console.error(`[visionService] credential file missing: ${keyFile}`);
-      throw new Error(`GOOGLE_APPLICATION_CREDENTIALS file not found at ${keyFile}`);
-    }
-    try {
-      JSON.parse(fs.readFileSync(keyFile, 'utf-8'));
-    } catch (err) {
-      console.error('[visionService] credential parse error =>', err.message);
-      console.error('[visionService] make sure GOOGLE_APPLICATION_CREDENTIALS points to a valid service account JSON');
-      throw new Error('GOOGLE_APPLICATION_CREDENTIALS file invalid');
-    }
-    try {
-      visionClient = new vision.ImageAnnotatorClient({ keyFilename: keyFile });
-    } catch (err) {
-      console.error('[visionService] failed to create Vision client =>', err.message);
-      if (err.code === 16) { // UNAUTHENTICATED
-        console.error('[visionService] authentication failed. Check your credential file and GOOGLE_APPLICATION_CREDENTIALS env variable.');
-      } else {
-        console.error('[visionService] unexpected error while creating Vision client =>', err);
-      }
-      throw err;
-    }
-  }
-  return visionClient;
-}
-
-// --- In-Memory LRU ---
-const lruMap = new Map(); // key: fileHash, val: { t, data }
-function setCache(k, data) {
-  lruMap.set(k, { t: Date.now(), data });
-  if (lruMap.size > LRU_CAPACITY) {
-    const oldestKey = [...lruMap.entries()].sort((a, b) => a[1].t - b[1].t)[0][0];
-    lruMap.delete(oldestKey);
-  }
-}
-function getCache(k) {
-  const hit = lruMap.get(k);
-  if (hit) {
-    hit.t = Date.now();
-    return hit.data;
-  }
-  return null;
-}
-
-// --- 壓縮工具 ---
-async function readAndMaybeCompress(filePath) {
-  const buf = fs.readFileSync(filePath);
-  if (buf.length <= COMPRESS_THRESHOLD) return buf;
-  try {
-    let out = await sharp(buf)
-      .resize({ width: 1600, height: 1600, fit: 'inside' })
-      .jpeg({ quality: 85 })
-      .toBuffer();
-    if (out.length > MAX_VISION_SIZE) {
-      out = await sharp(buf)
-        .resize({ width: 1200, height: 1200, fit: 'inside' })
-        .jpeg({ quality: 70 })
-        .toBuffer();
-    }
-    return out;
-  } catch (err) {
-    console.error('[visionService] compress fail => fallback to original', err);
-    return buf.slice(0, MAX_VISION_SIZE - 1024);
-  }
-}
-
-// --- 過濾連結 ---
-const INVALID_PREFIX_RE = /^(javascript:|data:)/i;
-const INVALID_CHAR_RE = /\s/;
-function isValidLink(u) {
-  if (!u) return false;
-  const trimmed = u.trim();
-  if (INVALID_PREFIX_RE.test(trimmed) || INVALID_CHAR_RE.test(trimmed)) return false;
-  try {
-    const uo = new URL(trimmed);
-    return uo.protocol === 'http:' || uo.protocol === 'https:';
-  } catch {
-    return false;
-  }
-}
-
-/**
- * 取得 Google Vision WebDetection 結果網址清單
- * - 合併 fullMatchingImages / partialMatchingImages / pagesWithMatchingImages
- * @param {string} filePath - 本機圖檔路徑
- * @param {number} [maxResults] - 回傳數量上限 (預設由環境變數 VISION_MAX_RESULTS 決定，預設 50)
- * @returns {Promise<string[]>}
- */
+const TMP_PATH = '/app/uploads/tmp/scan_for_vision.jpg';
+const DEFAULT_KEY_FILE = process.env.GOOGLE_APPLICATION_CREDENTIALS || '/app/credentials/gcp-vision.json';
 const DEFAULT_MAX_RESULTS = parseInt(process.env.VISION_MAX_RESULTS, 10) || 50;
+let client;
+
+function getClient() {
+  if (!client) {
+    console.log(`[visionService] using credential file: ${DEFAULT_KEY_FILE}`);
+    client = new vision.ImageAnnotatorClient({ keyFilename: DEFAULT_KEY_FILE });
+  }
+  return client;
+}
+
+async function convertToJpeg(src) {
+  await sharp(src).jpeg({ quality: 80 }).toFile(TMP_PATH);
+  return TMP_PATH;
+}
 
 async function getVisionPageMatches(filePath, maxResults = DEFAULT_MAX_RESULTS) {
-  if (!fs.existsSync(filePath)) {
-    throw new Error('FILE_NOT_FOUND: ' + filePath);
-  }
-  const stat = fs.statSync(filePath);
-  if (!stat.isFile()) throw new Error('EXPECTED_A_FILE: ' + filePath);
-
-  const hashKey = `${stat.size}_${crypto.createHash('sha1').update(fs.readFileSync(filePath)).digest('hex')}`;
-  const cacheHit = getCache(hashKey);
-  if (cacheHit) {
-    return cacheHit.slice(0, maxResults);
-  }
-
-  let urls = [];
+  if (!fs.existsSync(filePath)) throw new Error('FILE_NOT_FOUND: ' + filePath);
+  const tmp = await convertToJpeg(filePath);
   try {
-    const buf = await readAndMaybeCompress(filePath);
+    const buf = fs.readFileSync(tmp);
     const [res] = await getClient().webDetection({ image: { content: buf }, maxResults });
     const wd = res.webDetection || {};
-    urls = [
+    const urls = [
       ...(wd.fullMatchingImages || []).map(i => i.url),
       ...(wd.partialMatchingImages || []).map(i => i.url),
       ...(wd.pagesWithMatchingImages || []).map(p => p.url)
-    ].filter(isValidLink);
+    ].filter(u => {
+      try { return ['http:', 'https:'].includes(new URL(u).protocol); } catch { return false; }
+    });
+    return [...new Set(urls)].slice(0, maxResults);
   } catch (err) {
-    console.error('[visionService] getVisionPageMatches fail =>', err.message);
-    return [];
+    const msg = err.message || '';
+    if (msg.includes('DECODER') || msg.includes('unsupported') || msg.includes('UNKNOWN')) {
+      console.error('[visionService] getVisionPageMatches fail =>', msg);
+      return [];
+    }
+    throw err;
+  } finally {
+    try { fs.unlinkSync(tmp); } catch {}
   }
-
-  const unique = [...new Set(urls)].slice(0, maxResults);
-  setCache(hashKey, unique);
-  console.log(`[visionService] matched => ${filePath} =>`, unique);
-  return unique;
 }
 
-module.exports = {
-  getVisionPageMatches
-};
+module.exports = { getVisionPageMatches };


### PR DESCRIPTION
## Summary
- rework vision service to convert images to JPEG and return empty results on decoding errors
- ensure TinEye API key is required and update request helpers
- sync infringement route with new config variables
- remove quotes from `TINEYE_API_KEY` in `.env`

## Testing
- `docker compose build suzoo_express` *(fails: command not found)*
- `docker compose up -d suzoo_express` *(fails: command not found)*
- `docker compose logs suzoo_express --tail=50 | grep -E "visionService|getVisionPageMatches|TinEye 搜索失败"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849577ef88c8324afaa9a20a2e5ea8f