### PR TITLE
fix: swallow vision decoder errors; enforce tinEye API key check

### DIFF
--- a/express/services/visionService.js
+++ b/express/services/visionService.js
@@ -79,13 +79,8 @@ async function getVisionPageMatches(filePath, maxResults = VISION_MAX_RESULTS) {
     return [...new Set(urls)].slice(0, maxResults);
 
   } catch (err) {
-    const msg = String(err.message || '');
-    if (msg.includes('DECODER') || msg.includes('unsupported') || msg.includes('UNKNOWN')) {
-      console.error('[visionService] getVisionPageMatches fail =>', msg);
-      return [];
-    }
-    // 其它错误抛出
-    throw err;
+    console.error('[visionService] getVisionPageMatches fail =>', err.message || err);
+    return [];
 
   } finally {
     // 清理临时文件


### PR DESCRIPTION
## Summary
- swallow errors in `getVisionPageMatches`
- keep TinEye API key required check

## Testing
- `npm test` *(fails: Missing script)*
- `docker compose build suzoo_express` *(fails: `docker: command not found`)*
- `docker compose up -d suzoo_express` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684967612e788324869132050ef2d6ab