### PR TITLE
Enhance credential checks and TinEye error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ docker-compose up --build
    `docker-compose.yml` 會自動將 `./credentials` 掛載到 `/app/credentials`（唯讀）。
 4. 真實金鑰檔案已被 `.gitignore` 排除，請勿提交至版本庫。
 
+若啟動時出現 `DECODER routines::unsupported` 等錯誤，通常表示金鑰內容無法解析。
+請重新下載服務帳戶金鑰並確認 `private_key` 與 `client_email` 欄位完整。
+
 
 ## TinEye API
 

--- a/express/services/tineyeApiService.js
+++ b/express/services/tineyeApiService.js
@@ -21,6 +21,9 @@ async function searchByUrl(imageUrl, options = {}) {
     headers: { 'X-API-Key': API_KEY },
     validateStatus: () => true
   });
+  if (resp.status === 401 || resp.status === 403) {
+    throw new Error('TinEye API authentication failed');
+  }
   if (resp.status !== 200) {
     throw new Error(`TinEye 搜索失败：${resp.status}`);
   }
@@ -50,6 +53,9 @@ async function searchByFile(filePath, options = {}) {
       validateStatus: () => true
     }
   );
+  if (resp.status === 401 || resp.status === 403) {
+    throw new Error('TinEye API authentication failed');
+  }
   if (resp.status !== 200) {
     throw new Error(`TinEye 搜索失败：${resp.status}`);
   }

--- a/express/services/visionService.js
+++ b/express/services/visionService.js
@@ -16,12 +16,21 @@ let client;
  */
 function getClient() {
   if (!client) {
-    // 检查并报错如果凭证文件不存在
+    // 檢查並驗證憑證檔案
     const keyFile = process.env.GOOGLE_APPLICATION_CREDENTIALS || DEFAULT_KEY_FILE;
     if (!fs.existsSync(keyFile)) {
       throw new Error(`Vision credential file missing: ${keyFile}`);
     }
-    console.log(`[visionService] using credential file: ${keyFile}`);
+    let cred;
+    try {
+      cred = JSON.parse(fs.readFileSync(keyFile, 'utf-8'));
+      if (!cred.private_key || !cred.client_email) {
+        throw new Error('missing private_key or client_email');
+      }
+    } catch (e) {
+      throw new Error(`Vision credential invalid: ${e.message}`);
+    }
+    console.log(`[visionService] using credential file: ${keyFile} (${cred.client_email})`);
     client = new vision.ImageAnnotatorClient({ keyFilename: keyFile });
   }
   return client;


### PR DESCRIPTION
## Summary
- validate Google Vision credentials earlier and log client email
- surface TinEye API auth errors
- document Vision credential troubleshooting

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b08f93e88324aa2ea0bb54949953