### PR TITLE
Switch Docker images to CPU only

### DIFF
--- a/ai_service/Dockerfile
+++ b/ai_service/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:1.13.1-cuda11.6-cudnn8-runtime
+FROM pytorch/pytorch:1.13.1-cpu
 
 # 安裝必要套件 (含 opencv)
 RUN apt-get update && apt-get install -y libgl1-mesa-glx && rm -rf /var/lib/apt/lists/*

--- a/ai_service/requirements.txt
+++ b/ai_service/requirements.txt
@@ -1,6 +1,6 @@
 Flask==2.1.3
-torch==1.13.1
-torchvision==0.14.1
+torch==1.13.1+cpu --find-links https://download.pytorch.org/whl/cpu/torch_stable.html
+torchvision==0.14.1+cpu --find-links https://download.pytorch.org/whl/cpu/torch_stable.html
 torchattacks==3.3.0
 opencv-python==4.6.0.66
 numpy==1.23.5

--- a/python_crawlers/Dockerfile
+++ b/python_crawlers/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:1.13.1-cuda11.6-cudnn8-runtime
+FROM pytorch/pytorch:1.13.1-cpu
 
 WORKDIR /app
 

--- a/python_crawlers/requirements.txt
+++ b/python_crawlers/requirements.txt
@@ -2,12 +2,12 @@ celery
 requests
 beautifulsoup4
 pymilvus
-torch==1.13.1
+torch==1.13.1+cpu --find-links https://download.pytorch.org/whl/cpu/torch_stable.html
 transformers
 pillow
 sentence_transformers
 ffmpeg-python
 opencv-python
 open_clip_torch
-torchvision==0.14.1
+torchvision==0.14.1+cpu --find-links https://download.pytorch.org/whl/cpu/torch_stable.html
 pytube


### PR DESCRIPTION
## Summary
- update python crawler and AI service Dockerfiles to use CPU base image
- update Python requirements to install CPU wheels for torch and torchvision

## Testing
- `npm test` *(fails: Missing script)*
- `docker compose build ai_service python_crawlers` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684ad6b9417c8324a570fab0f4ea2e4f