### PR TITLE
Fix Docker build by updating PyTorch base image tags

### DIFF
--- a/ai_service/Dockerfile
+++ b/ai_service/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:1.13.1-cpu
+FROM pytorch/pytorch:1.13.1-cuda11.6-cudnn8-runtime
 
 # 安裝必要套件 (含 opencv)
 RUN apt-get update && apt-get install -y libgl1-mesa-glx && rm -rf /var/lib/apt/lists/*

--- a/python_crawlers/Dockerfile
+++ b/python_crawlers/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:1.13.1-cpu
+FROM pytorch/pytorch:1.13.1-cuda11.6-cudnn8-runtime
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- update `ai_service` Dockerfile to use `pytorch/pytorch:1.13.1-cuda11.6-cudnn8-runtime`
- update `python_crawlers` Dockerfile to use the same base image

## Testing
- `docker pull --quiet pytorch/pytorch:1.13.1-cuda11.6-cudnn8-runtime` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684adc503a8c8324ac9b87808016113e