### PR TITLE
Fix apt path in Dockerfiles

### DIFF
--- a/python-vector-service/Dockerfile
+++ b/python-vector-service/Dockerfile
@@ -2,8 +2,7 @@
 FROM python:3.9-slim
 
 # 替换国内源，Debian slim 把源放在 sources.list.d 里
-RUN sed -i 's#deb.debian.org#mirrors.aliyun.com#g' \
-    /etc/apt/sources.list.d/debian.sources.list \
+RUN sed -i 's#http://deb.debian.org#http://mirrors.aliyun.com#g' /etc/apt/sources.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
        build-essential libgl1 \

--- a/python_crawlers/Dockerfile
+++ b/python_crawlers/Dockerfile
@@ -1,8 +1,7 @@
 FROM pytorch/pytorch:1.13.1-cuda11.6-cudnn8-runtime
 
 # 替换国内源，Debian slim 把源放在 sources.list.d 里
-RUN sed -i 's#deb.debian.org#mirrors.aliyun.com#g' \
-    /etc/apt/sources.list.d/debian.sources.list \
+RUN sed -i 's#http://deb.debian.org#http://mirrors.aliyun.com#g' /etc/apt/sources.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends build-essential \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- update `python-vector-service` Dockerfile apt source path
- update `python_crawlers` Dockerfile apt source path

## Testing
- `docker build` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bcac4dcfc8324aedc9f1ddd582c5a