### PR TITLE
Fix Debian apt path in Dockerfiles

### DIFF
--- a/python-vector-service/Dockerfile
+++ b/python-vector-service/Dockerfile
@@ -2,7 +2,8 @@
 FROM python:3.9-slim
 
 # 替换国内源，Debian slim 把源放在 sources.list.d 里
-RUN sed -i 's#http://deb.debian.org#http://mirrors.aliyun.com#g' /etc/apt/sources.list \
+RUN [ -f /etc/apt/sources.list ] && sed -i 's#deb.debian.org#mirrors.aliyun.com#g' /etc/apt/sources.list || true \
+    && find /etc/apt/sources.list.d -name '*.list' -exec sed -i 's#deb.debian.org#mirrors.aliyun.com#g' {} + \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
        build-essential libgl1 \

--- a/python_crawlers/Dockerfile
+++ b/python_crawlers/Dockerfile
@@ -1,7 +1,8 @@
 FROM pytorch/pytorch:1.13.1-cuda11.6-cudnn8-runtime
 
 # 替换国内源，Debian slim 把源放在 sources.list.d 里
-RUN sed -i 's#http://deb.debian.org#http://mirrors.aliyun.com#g' /etc/apt/sources.list \
+RUN ( [ -f /etc/apt/sources.list ] && sed -i 's#deb.debian.org#mirrors.aliyun.com#g' /etc/apt/sources.list || true ) \
+    && find /etc/apt/sources.list.d -name '*.list' -exec sed -i 's#deb.debian.org#mirrors.aliyun.com#g' {} + \
     && apt-get update \
     && apt-get install -y --no-install-recommends build-essential \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- handle Debian slim apt source path variations in python-vector-service Dockerfile
- handle Debian slim apt source path variations in python_crawlers Dockerfile

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: network blocked for puppeteer download)*

------
https://chatgpt.com/codex/tasks/task_e_684bce629d48832486cfb1941d20d9b8