### PR TITLE
Fix .env credential paths and use env var in compose

### DIFF
--- a/.env
+++ b/.env
@@ -111,9 +111,9 @@ VECTOR_SERVICE_URL=http://suzoo_python_vector:8000
 ########################################
 # 反向圖搜 API
 ########################################
-GOOGLE_APPLICATION_CREDENTIALS=./credentials/gcp-vision.json
+GOOGLE_APPLICATION_CREDENTIALS=/app/credentials/gcp-vision.json
 
 ########################################
 # TinEye 反向圖搜尋 API (最關鍵)
 ########################################
-TINEYE_API_KEY=29Qtdgo7xo_ec9_cNDh^PhOcXKc,aaHYiVgXIYhy
+TINEYE_API_KEY="29Qtdgo7xo_ec9_cNDh^PhOcXKc,aaHYiVgXIYhy"

--- a/.env.example
+++ b/.env.example
@@ -111,10 +111,10 @@ VECTOR_SERVICE_URL=http://suzoo_python_vector:8000
 ########################################
 # Google Cloud Vision
 ########################################
-GOOGLE_APPLICATION_CREDENTIALS=./credentials/gcp-vision.json
+GOOGLE_APPLICATION_CREDENTIALS=/app/credentials/gcp-vision.json
 VISION_MAX_RESULTS=50
 
 ########################################
 # TinEye 反向圖搜尋 API
 ########################################
-TINEYE_API_KEY=29Qtdgo7xo_ec9_cNDh^PhOcXKc,aaHYiVgXIYhy
+TINEYE_API_KEY="29Qtdgo7xo_ec9_cNDh^PhOcXKc,aaHYiVgXIYhy"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       PYTHON_VECTOR_URL: http://suzoo_python_vector:8000
 
       # ★★★ 新增：Google Vision SDK 將自動讀取此路徑 ★★★
-      GOOGLE_APPLICATION_CREDENTIALS: /app/credentials/gcp-vision.json
+      GOOGLE_APPLICATION_CREDENTIALS: ${GOOGLE_APPLICATION_CREDENTIALS}
 
       # ★★★ 新增：TinEye API Key (修正錯誤) ★★★
       TINEYE_API_KEY: ${TINEYE_API_KEY}


### PR DESCRIPTION
## Summary
- fix Google Cloud Vision path to use absolute location
- quote TinEye API key containing special characters
- update docker compose to read credential path from `.env`

## Testing
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684fb667244c83248cf614bd4d61a7a5