### PR TITLE
Fix infringe scan utilities

### DIFF
--- a/express/services/visionService.js
+++ b/express/services/visionService.js
@@ -74,6 +74,12 @@ async function infringementScan({ buffer }) {
   };
 }
 
+async function searchVisionByBuffer(buffer){
+  const { vision } = await infringementScan({ buffer });
+  return vision.links;
+}
+
 module.exports = {
   infringementScan,
+  searchVisionByBuffer,
 };


### PR DESCRIPTION
## Summary
- export `searchVisionByBuffer` from `visionService`
- adjust vector search utilities to hit correct endpoints and use base64 payloads

## Testing
- `npm test` *(fails: jest not found)*
- `npm run vision:test` *(fails: cannot find module @google-cloud/vision)*
- `bash check_infringement.sh`

------
https://chatgpt.com/codex/tasks/task_e_684fbce94c8c8324916f7cec8dda3a51