### PR TITLE
Setup pnpm monorepo tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,15 @@ POSTGRES_PASSWORD=KaiShieldDbPass2023!
 POSTGRES_DB=suzoo
 POSTGRES_HOST=suzoo_postgres
 POSTGRES_PORT=5432
+# Redis
+REDIS_HOST=suzoo_redis
+REDIS_PORT=6379
+
+# RabbitMQ
+RABBITMQ_USER=admin
+RABBITMQ_PASS=admin
+RABBITMQ_URL=amqp://admin:admin@suzoo_rabbitmq:5672
+
 
 ########################################
 # JWT

--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,8 @@ RABBITMQ_URL=amqp://admin:admin@suzoo_rabbitmq:5672
 # JWT
 ########################################
 JWT_SECRET=ZmVkOWY4ZDItNWU3MC00NDM5LW
+JWT_ACCESS_SECRET=your_super_secret_for_access_token
+JWT_REFRESH_SECRET=your_super_secret_for_refresh_token
 
 ########################################
 # Cloudinary

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,21 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint', 'prettier'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended'
+  ],
+  env: {
+    node: true,
+    es2021: true
+  },
+  rules: {
+    'prettier/prettier': 'error',
+    '@typescript-eslint/no-explicit-any': 'warn',
+    '@typescript-eslint/interface-name-prefix': 'off',
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off'
+  }
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 fastapi.log
 nginx.log
 credentials/*.json
+
+node_modules
+.env
+dist
+.next
+coverage
+.turbo

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm exec lint-staged

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "trailingComma": "all",
+  "singleQuote": true,
+  "printWidth": 120,
+  "tabWidth": 2
+}

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ JWT_REFRESH_SECRET=your_super_secret_for_refresh_token
 docker-compose up --build
 ```
 
+在服務啟動後，Docker Compose 會根據 healthcheck 等待核心服務就緒。
 ## 設定 Google Cloud Vision API
 
 1. 於 [Google Cloud Console](https://console.cloud.google.com/) 建立專案並啟用 **Vision API**。

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ AWS_SECRET_KEY=your_aws_secret_key
 GOOGLE_APPLICATION_CREDENTIALS=./credentials/gcp-vision.json
 VISION_MAX_RESULTS=50
 TINEYE_API_KEY=your_tineye_api_key
+JWT_ACCESS_SECRET=your_super_secret_for_access_token
+JWT_REFRESH_SECRET=your_super_secret_for_refresh_token
 ```
 
 ## 使用 Docker Compose 啟動整套系統

--- a/README.md
+++ b/README.md
@@ -91,3 +91,22 @@ Express 服務在 `/api/protect` 下提供上述端點，前端在完成上傳�
 docker compose build suzoo_express
 docker compose up -d suzoo_express
 ```
+
+## Monorepo Workflow
+
+專案採用 pnpm 與 Turborepo 管理多個服務，開發前可執行：
+
+```bash
+corepack enable
+corepack prepare pnpm@latest --activate
+pnpm install
+```
+
+常用指令：
+
+```bash
+pnpm dev    # 啟動所有服務
+pnpm build  # 建構所有套件
+pnpm lint   # 執行 ESLint
+pnpm test   # 執行測試
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,12 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-  redis_data:
-    networks:
-      - suzoo_net
-    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   suzoo_redis:
     container_name: suzoo_redis
@@ -211,6 +213,12 @@ services:
     ports:
       - "5672:5672"
       - "15672:15672"
+    healthcheck:
+      test: ["CMD-SHELL", "rabbitmq-diagnostics -q ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     networks:
       - suzoo_net
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,18 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+  redis_data:
+    networks:
+      - suzoo_net
+    restart: unless-stopped
+
+  suzoo_redis:
+    container_name: suzoo_redis
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
     networks:
       - suzoo_net
     restart: unless-stopped
@@ -258,6 +270,7 @@ services:
 
 volumes:
   postgres_data:
+  redis_data:
   uploads_data:   # ★★★ 對應 /app/uploads ★★★
 
 networks:

--- a/package.json
+++ b/package.json
@@ -2,5 +2,31 @@
   "dependencies": {
     "jwt-decode": "^4.0.0",
     "styled-components": "^6.1.17"
+  },
+  "scripts": {
+    "build": "turbo run build",
+    "dev": "turbo run dev",
+    "lint": "turbo run lint",
+    "test": "turbo run test"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "packageManager": "pnpm@10.5.2",
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "@types/node": "^20.9.0",
+    "eslint": "^8.56.0",
+    "prettier": "^2.8.8",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-prettier": "^5.0.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
+    "husky": "^8.0.0",
+    "lint-staged": "^15.0.0",
+    "turbo": "^1.11.3"
+  },
+  "lint-staged": {
+    "*.{js,ts,jsx,tsx}": "eslint --fix"
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+packages:
+  - 'frontend'
+  - 'express'
+  - 'fastapi'
+  - 'python-vector-service'
+  - 'python_crawlers'
+  - 'api_service'
+  - 'ai_service'

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "commonjs",
+    "lib": ["es2021"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "sourceMap": true,
+    "declaration": true,
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", ".next/**"]
+    },
+    "lint": {},
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "test": {
+      "dependsOn": ["build"],
+      "inputs": ["src/**/*.ts", "tests/**/*.ts"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add pnpm workspace and turbo.json
- introduce shared tsconfig, eslint and prettier configs
- add husky pre-commit hook with lint-staged
- expand `.gitignore`
- update docker compose with redis service
- document pnpm workflow
- extend env example with Redis and RabbitMQ vars

## Testing
- `pnpm test` *(fails: Test Suites: 2 failed)*

------
https://chatgpt.com/codex/tasks/task_e_685149df4f7083248cb63c87a331b948