### PR TITLE
Fix gitignore for monorepo tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dist
 .next
 coverage
 .turbo
+
+pnpm-lock.yaml


### PR DESCRIPTION
## Summary
- ignore `pnpm-lock.yaml`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: sharp module install + TINEYE_API_KEY/vision API errors)*

------
https://chatgpt.com/codex/tasks/task_e_68517eb5cd588324a07ad161343eb0fc