### PR TITLE
Add DB connection retries to express server

### DIFF
--- a/.env
+++ b/.env
@@ -118,3 +118,5 @@ GOOGLE_APPLICATION_CREDENTIALS=/app/credentials/gcp-vision.json
 ########################################
 TINEYE_API_KEY="29Qtdgo7xo_ec9_cNDh^PhOcXKc,aaHYiVgXIYhy"
 GOOGLE_APPLICATION_CREDENTIALS=./credentials/gcp-vision.json
+DB_CONNECT_RETRIES=5
+DB_CONNECT_RETRY_DELAY=5000

--- a/.env.example
+++ b/.env.example
@@ -130,3 +130,5 @@ VISION_MAX_RESULTS=50
 ########################################
 TINEYE_API_KEY="29Qtdgo7xo_ec9_cNDh^PhOcXKc,aaHYiVgXIYhy"
 GOOGLE_APPLICATION_CREDENTIALS=./credentials/gcp-vision.json
+DB_CONNECT_RETRIES=5
+DB_CONNECT_RETRY_DELAY=5000


### PR DESCRIPTION
## Summary
- add retry mechanism for Sequelize connection in express server
- expose retry settings via `DB_CONNECT_RETRIES` and `DB_CONNECT_RETRY_DELAY` in `.env` and `.env.example`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685268f2c91c832483a0f1ebb5dbabce