### PR TITLE
Fix Postgres network in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       timeout: 5s
       retries: 5
       start_period: 30s
+    networks:
+      - suzoo_net
 
   suzoo_redis:
     container_name: suzoo_redis


### PR DESCRIPTION
## Summary
- add `suzoo_net` network to the postgres service so express can resolve the DB host

## Testing
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68526bb5b2e88324ba6290865a49b3b1