### PR TITLE
Improve service startup resilience

### DIFF
--- a/.env
+++ b/.env
@@ -118,5 +118,5 @@ GOOGLE_APPLICATION_CREDENTIALS=/app/credentials/gcp-vision.json
 ########################################
 TINEYE_API_KEY="29Qtdgo7xo_ec9_cNDh^PhOcXKc,aaHYiVgXIYhy"
 GOOGLE_APPLICATION_CREDENTIALS=./credentials/gcp-vision.json
-DB_CONNECT_RETRIES=5
-DB_CONNECT_RETRY_DELAY=5000
+DB_CONNECT_RETRIES=20
+DB_CONNECT_RETRY_DELAY=10000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,10 +75,14 @@ services:
       # Puppeteer 新版 Headless 警告抑制
       PUPPETEER_HEADLESS: "new"
     depends_on:
-      - suzoo_postgres
-      - suzoo_ipfs
-      - suzoo_ganache
-      - suzoo_milvus
+      suzoo_postgres:
+        condition: service_healthy
+      suzoo_ipfs:
+        condition: service_started
+      suzoo_ganache:
+        condition: service_started
+      suzoo_milvus:
+        condition: service_started
     ports:
       - "3000:3000"
     networks:


### PR DESCRIPTION
## Summary
- raise DB retry counts to allow more time for PostgreSQL startup
- block service start until dependency health checks pass

## Testing
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68527232d380832482b59086044dbc7d