### PR TITLE
Add screenshot to infringement PDF

### DIFF
--- a/express/routes/protect.js
+++ b/express/routes/protect.js
@@ -1009,11 +1009,27 @@ router.get('/scan/:fileId', async(req,res)=>{
     const scanPdfPath= path.join(REPORTS_DIR, scanPdfName);
     const stampPath= path.join(__dirname, '../../public/stamp.png');
 
+    let shotPath = null;
+    if (truncated.length > 0) {
+      const browser = await launchBrowser();
+      try {
+        const page = await browser.newPage();
+        await page.goto(truncated[0], { waitUntil:'domcontentloaded', timeout:30000 }).catch(()=>{});
+        const shotDir = path.join(UPLOAD_BASE_DIR, 'infringe_shots');
+        if(!fs.existsSync(shotDir)) fs.mkdirSync(shotDir, { recursive:true });
+        shotPath = path.join(shotDir, `file_${fileRec.id}_${Date.now()}.png`);
+        await page.screenshot({ path: shotPath, fullPage:true }).catch(()=>{});
+      } finally {
+        await browser.close().catch(()=>{});
+      }
+    }
+
     await generateScanPDFWithMatches({
       file: fileRec,
       suspiciousLinks: truncated,
       matchedImages,
-      stampImagePath: fs.existsSync(stampPath)? stampPath:null
+      stampImagePath: fs.existsSync(stampPath)? stampPath:null,
+      screenshotPath: shotPath
     }, scanPdfPath);
 
     return res.json({
@@ -1101,6 +1117,20 @@ router.get('/scanLink', async(req,res)=>{
     const pdfName = `linkScanReport_${Date.now()}.pdf`;
     const pdfPath = path.join(REPORTS_DIR, pdfName);
 
+    let shotPath = null;
+    try {
+      const browser = await launchBrowser();
+      const page = await browser.newPage();
+      await page.goto(pageUrl, { waitUntil:'domcontentloaded', timeout:30000 }).catch(()=>{});
+      const shotDir = path.join(UPLOAD_BASE_DIR, 'infringe_shots');
+      if(!fs.existsSync(shotDir)) fs.mkdirSync(shotDir, { recursive:true });
+      shotPath = path.join(shotDir, `link_${Date.now()}.png`);
+      await page.screenshot({ path: shotPath, fullPage:true }).catch(()=>{});
+      await browser.close();
+    } catch(e){
+      console.error('[scanLink screenshot error]', e);
+    }
+
     await generateScanPDFWithMatches({
       file: {
         id: '(linkScan)',
@@ -1112,7 +1142,8 @@ router.get('/scanLink', async(req,res)=>{
       matchedImages,
       stampImagePath: fs.existsSync(path.join(__dirname, '../../public/stamp.png'))
         ? path.join(__dirname, '../../public/stamp.png')
-        : null
+        : null,
+      screenshotPath: shotPath
     }, pdfPath);
 
     // 清理暫存

--- a/express/services/pdfService.js
+++ b/express/services/pdfService.js
@@ -158,10 +158,11 @@ async function generateReport(filePath, results) {
  *   - matchedImages: Array<{id:string, score:number, base64:string}>
  *   - stampImagePath: (可選) 浮水印圖
  *   - cachedHtmlContent: (可選) 來自各平台的 HTML 字串快取
+ *   - screenshotPath: (可選) 侵權頁面截圖路徑
  * @param {string} outputPath - 輸出PDF檔案路徑
  */
 async function generateScanPDFWithMatches(
-  { file, suspiciousLinks, matchedImages, stampImagePath, cachedHtmlContent },
+  { file, suspiciousLinks, matchedImages, stampImagePath, cachedHtmlContent, screenshotPath },
   outputPath
 ) {
   return new Promise((resolve, reject) => {
@@ -225,6 +226,13 @@ async function generateScanPDFWithMatches(
           doc.fontSize(10).fillColor('gray').text(summary);
           doc.moveDown();
         });
+        doc.moveDown();
+      }
+
+      // (NEW) 侵權頁面截圖
+      if (screenshotPath && fs.existsSync(screenshotPath)) {
+        doc.fontSize(14).text('偵測到侵權頁面截圖:', { underline: true });
+        doc.image(screenshotPath, { fit: [500, 400], align: 'center' });
         doc.moveDown();
       }
 

--- a/frontend/src/pages/ProtectStep4Infringement.jsx
+++ b/frontend/src/pages/ProtectStep4Infringement.jsx
@@ -102,22 +102,9 @@ export default function ProtectStep4Infringement() {
   } = info;
 
   /**
-   * 方法1：用 window.open 在新分頁打開 PDF
+   * 直接下載 PDF
    */
-  const handleDownloadScanPdfNewTab = () => {
-    if (!scanReportUrl) {
-      alert('無法找到「侵權偵測報告 PDF」的下載連結');
-      return;
-    }
-    // 直接開新分頁
-    window.open(scanReportUrl, '_blank');
-  };
-
-  /**
-   * 方法2：直接下載 PDF
-   * 說明：若想直接下載檔案，可改用此函數
-   */
-  const handleDownloadScanPdfDirect = () => {
+  const handleDownloadScanPdf = () => {
     if (!scanReportUrl) {
       alert('無法找到「侵權偵測報告 PDF」的下載連結');
       return;
@@ -159,13 +146,8 @@ export default function ProtectStep4Infringement() {
         )}
 
         <div style={{ marginTop:'1.5rem' }}>
-          {/* 按鈕1：預設用「新分頁開啟 PDF」 */}
-          <Button onClick={handleDownloadScanPdfNewTab}>
-            下載侵權偵測報告 (另開視窗)
-          </Button>
-          {/* 按鈕2：可選用「直接下載」功能，若不需要可隱藏或移除 */}
-          <Button onClick={handleDownloadScanPdfDirect}>
-            直接下載 PDF
+          <Button onClick={handleDownloadScanPdf}>
+            下載侵權偵測報告
           </Button>
 
           <Button onClick={() => navigate('/')}>


### PR DESCRIPTION
## Summary
- include optional screenshot in `generateScanPDFWithMatches`
- capture first suspicious link screenshot when scanning
- capture screenshot when scanning link directly
- simplify PDF download UI

## Testing
- `npm test` *(fails: Vision/TinEye env vars not set)*

------
https://chatgpt.com/codex/tasks/task_e_68527f5db8a48324a8ad8ca9a9a0bf8b