### PR TITLE
Fix Express middleware registration

### DIFF
--- a/express/server.js
+++ b/express/server.js
@@ -8,6 +8,9 @@ const path          = require('path');
 const puppeteer     = require('puppeteer');
 
 const app = express();
+app.use(cors());
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 
 /*───────────────────────────────────  
  | 路由 import  
@@ -24,10 +27,6 @@ const infringementRouter = require('./routes/infringement');     // 侵權相關
 /*───────────────────────────────────  
  | 1. 中介層  
  *───────────────────────────────────*/
-app.use(cors());
-app.use(express.json());
-// Allow parsing of application/x-www-form-urlencoded bodies
-app.use(express.urlencoded({ extended: true }));
 
 /*───────────────────────────────────  
  | 2. uploads 對外靜態目錄  


### PR DESCRIPTION
## Summary
- centralize body parser & cors middlewares after `const app`

## Testing
- `docker compose up -d --build suzoo_express` *(fails: `docker` not found)*
- `curl -v -X POST http://localhost:3000/api/admin/login -H "Content-Type: application/json" -d '{"identifier":"zacyao1005","password":"你的密码"}'` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6852c83e4ed88324a6dedb2ffa1d13f0