### PR TITLE
Configure TikTok RapidAPI

### DIFF
--- a/.env
+++ b/.env
@@ -28,6 +28,7 @@ CLOUDINARY_API_SECRET=CBLyksZYM6udCSY2-Jhv3a4E5dI
 # RapidAPI (DMCA)
 ########################################
 RAPIDAPI_KEY=71dbbf39f7msh794002260b4e71bp1025e2jsn652998e0f81a
+RAPIDAPI_HOST=tiktok-scraper7.p.rapidapi.com
 
 ########################################
 # Ganache RPC URL & Private Key

--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,7 @@ CLOUDINARY_API_SECRET=CBLyksZYM6udCSY2-Jhv3a4E5dI
 # RapidAPI (DMCA)
 ########################################
 RAPIDAPI_KEY=71dbbf39f7msh794002260b4e71bp1025e2jsn652998e0f81a
+RAPIDAPI_HOST=tiktok-scraper7.p.rapidapi.com
 
 ########################################
 # Ganache RPC URL & Private Key

--- a/crawler/index.js
+++ b/crawler/index.js
@@ -34,11 +34,17 @@ async function mainCrawler() {
     const token = await loginExpress();
     console.log('[Crawler] 已取得後端 token:', token);
     
-    // 範例：呼叫 RapidAPI 取得疑似侵權清單
-    // 注意：此 URL 僅為示範，請根據實際需求修改
-    const resp = await axios.get('https://example-rapidapi.com/infringements', {
-      headers: { 'X-RapidAPI-Key': RAPIDAPI_KEY }
-    });
+    // 呼叫 RapidAPI 的 TikTok API
+    const resp = await axios.get(
+      'https://tiktok-scraper7.p.rapidapi.com/featured/list/entertainment',
+      {
+        headers: {
+          'X-RapidAPI-Key': RAPIDAPI_KEY,
+          'X-RapidAPI-Host': process.env.RAPIDAPI_HOST
+        },
+        params: { cursor: '0' }
+      }
+    );
     const results = resp.data;
     console.log('[Crawler] 取得外部API結果:', results);
     

--- a/express/routes/protect.js
+++ b/express/routes/protect.js
@@ -929,7 +929,10 @@ router.get('/scan/:fileId', async(req,res)=>{
       try {
         const rTT= await axios.get('https://tiktok-scraper7.p.rapidapi.com/feed/search',{
           params:{ keywords: query, region:'us', count:'3' },
-          headers:{ 'X-RapidAPI-Key': process.env.RAPIDAPI_KEY },
+          headers:{
+            'X-RapidAPI-Key': process.env.RAPIDAPI_KEY,
+            'X-RapidAPI-Host': process.env.RAPIDAPI_HOST
+          },
           timeout:10000
         });
         const items= rTT.data?.videos||[];


### PR DESCRIPTION
## Summary
- add `RAPIDAPI_HOST` variable
- include host header when calling TikTok API
- update crawler to use real TikTok endpoint

## Testing
- `pnpm test` *(fails: suzoo-express tests)*

------
https://chatgpt.com/codex/tasks/task_e_6853d514a9f08324b489cd774b2f3f61