### PR TITLE
Add RapidAPI social platform search

### DIFF
--- a/express/services/rapidApiService.js
+++ b/express/services/rapidApiService.js
@@ -1,0 +1,88 @@
+const axios = require('axios');
+
+async function tiktokSearch(keyword) {
+  console.log('[RapidAPI][TikTok] request:', keyword);
+  const url = 'https://tiktok-scraper7.p.rapidapi.com/feed/search';
+  try {
+    const res = await axios.get(url, {
+      params: { keywords: keyword, region: 'us', count: '3' },
+      headers: {
+        'X-RapidAPI-Key': process.env.RAPIDAPI_KEY,
+        'X-RapidAPI-Host': 'tiktok-scraper7.p.rapidapi.com',
+      },
+      timeout: 10000,
+    });
+    console.log('[RapidAPI][TikTok] status:', res.status);
+    return res.data;
+  } catch (err) {
+    console.error('[RapidAPI][TikTok] error:', err.message);
+    throw err;
+  }
+}
+
+async function instagramSearch(keyword) {
+  console.log('[RapidAPI][Instagram] request:', keyword);
+  const url = 'https://instagram-data1.p.rapidapi.com/search';
+  try {
+    const res = await axios.get(url, {
+      params: { query: keyword, type: 'top' },
+      headers: {
+        'X-RapidAPI-Key': process.env.RAPIDAPI_KEY,
+        'X-RapidAPI-Host': 'instagram-data1.p.rapidapi.com',
+      },
+      timeout: 10000,
+    });
+    console.log('[RapidAPI][Instagram] status:', res.status);
+    return res.data;
+  } catch (err) {
+    console.error('[RapidAPI][Instagram] error:', err.message);
+    throw err;
+  }
+}
+
+async function facebookSearch(keyword) {
+  console.log('[RapidAPI][Facebook] request:', keyword);
+  const url = 'https://facebook-data1.p.rapidapi.com/search';
+  try {
+    const res = await axios.get(url, {
+      params: { query: keyword },
+      headers: {
+        'X-RapidAPI-Key': process.env.RAPIDAPI_KEY,
+        'X-RapidAPI-Host': 'facebook-data1.p.rapidapi.com',
+      },
+      timeout: 10000,
+    });
+    console.log('[RapidAPI][Facebook] status:', res.status);
+    return res.data;
+  } catch (err) {
+    console.error('[RapidAPI][Facebook] error:', err.message);
+    throw err;
+  }
+}
+
+async function youtubeSearch(keyword) {
+  console.log('[RapidAPI][YouTube] request:', keyword);
+  const url = 'https://youtube-search-results.p.rapidapi.com/youtube-search';
+  try {
+    const res = await axios.get(url, {
+      params: { q: keyword },
+      headers: {
+        'X-RapidAPI-Key': process.env.RAPIDAPI_KEY,
+        'X-RapidAPI-Host': 'youtube-search-results.p.rapidapi.com',
+      },
+      timeout: 10000,
+    });
+    console.log('[RapidAPI][YouTube] status:', res.status);
+    return res.data;
+  } catch (err) {
+    console.error('[RapidAPI][YouTube] error:', err.message);
+    throw err;
+  }
+}
+
+module.exports = {
+  tiktokSearch,
+  instagramSearch,
+  facebookSearch,
+  youtubeSearch,
+};


### PR DESCRIPTION
## Summary
- create `rapidApiService.js` to call TikTok, Instagram, Facebook and YouTube via RapidAPI
- integrate new service in `protect.js` to fetch links from all four platforms
- log calls and statuses for better diagnostics

## Testing
- `npm test --prefix express` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853ed71fab48324bf4e81fa7939172e