### PR TITLE
Fix RapidAPI hosts and handle non-array results

### DIFF
--- a/express/routes/protect.js
+++ b/express/routes/protect.js
@@ -933,7 +933,9 @@ router.get('/scan/:fileId', async(req,res)=>{
       try {
         const rTT = await rapidApiService.tiktokSearch(query);
         const items = rTT?.videos || rTT?.data || [];
-        items.forEach(v => { if(v.link) suspiciousLinks.push(v.link); });
+        if (Array.isArray(items)) {
+          items.forEach(v => { if (v.link) suspiciousLinks.push(v.link); });
+        }
       } catch(eTT){
         console.error('[scan Tiktok error]', eTT.message);
       }
@@ -941,7 +943,9 @@ router.get('/scan/:fileId', async(req,res)=>{
       try {
         const rIG = await rapidApiService.instagramSearch(query);
         const igItems = rIG?.results || rIG?.data || [];
-        igItems.forEach(v => { if(v.link || v.url) suspiciousLinks.push(v.link || v.url); });
+        if (Array.isArray(igItems)) {
+          igItems.forEach(v => { if (v.link || v.url) suspiciousLinks.push(v.link || v.url); });
+        }
       } catch(eIG){
         console.error('[scan Instagram error]', eIG.message);
       }
@@ -949,7 +953,9 @@ router.get('/scan/:fileId', async(req,res)=>{
       try {
         const rFB = await rapidApiService.facebookSearch(query);
         const fbItems = rFB?.results || rFB?.data || [];
-        fbItems.forEach(v => { if(v.link || v.url) suspiciousLinks.push(v.link || v.url); });
+        if (Array.isArray(fbItems)) {
+          fbItems.forEach(v => { if (v.link || v.url) suspiciousLinks.push(v.link || v.url); });
+        }
       } catch(eFB){
         console.error('[scan Facebook error]', eFB.message);
       }
@@ -957,7 +963,9 @@ router.get('/scan/:fileId', async(req,res)=>{
       try {
         const rYT = await rapidApiService.youtubeSearch(query);
         const ytItems = rYT?.items || rYT?.data || [];
-        ytItems.forEach(v => { if(v.link || v.url) suspiciousLinks.push(v.link || v.url); });
+        if (Array.isArray(ytItems)) {
+          ytItems.forEach(v => { if (v.link || v.url) suspiciousLinks.push(v.link || v.url); });
+        }
       } catch(eYT){
         console.error('[scan YouTube error]', eYT.message);
       }

--- a/express/services/rapidApiService.js
+++ b/express/services/rapidApiService.js
@@ -1,14 +1,19 @@
 const axios = require('axios');
 
+const TIKTOK_HOST = process.env.TIKTOK_HOST || 'tiktok-scraper7.p.rapidapi.com';
+const INSTAGRAM_HOST = process.env.INSTAGRAM_HOST || 'instagram-data1.p.rapidapi.com';
+const FACEBOOK_HOST = process.env.FACEBOOK_HOST || 'facebook-data1.p.rapidapi.com';
+const YOUTUBE_HOST = process.env.YOUTUBE_HOST || 'youtube-search-results.p.rapidapi.com';
+
 async function tiktokSearch(keyword) {
   console.log('[RapidAPI][TikTok] request:', keyword);
-  const url = 'https://tiktok-scraper7.p.rapidapi.com/feed/search';
+  const url = `https://${TIKTOK_HOST}/feed/search`;
   try {
     const res = await axios.get(url, {
       params: { keywords: keyword, region: 'us', count: '3' },
       headers: {
         'X-RapidAPI-Key': process.env.RAPIDAPI_KEY,
-        'X-RapidAPI-Host': 'tiktok-scraper7.p.rapidapi.com',
+        'X-RapidAPI-Host': TIKTOK_HOST,
       },
       timeout: 10000,
     });
@@ -22,13 +27,13 @@ async function tiktokSearch(keyword) {
 
 async function instagramSearch(keyword) {
   console.log('[RapidAPI][Instagram] request:', keyword);
-  const url = 'https://instagram-data1.p.rapidapi.com/search';
+  const url = `https://${INSTAGRAM_HOST}/search`;
   try {
     const res = await axios.get(url, {
       params: { query: keyword, type: 'top' },
       headers: {
         'X-RapidAPI-Key': process.env.RAPIDAPI_KEY,
-        'X-RapidAPI-Host': 'instagram-data1.p.rapidapi.com',
+        'X-RapidAPI-Host': INSTAGRAM_HOST,
       },
       timeout: 10000,
     });
@@ -42,13 +47,13 @@ async function instagramSearch(keyword) {
 
 async function facebookSearch(keyword) {
   console.log('[RapidAPI][Facebook] request:', keyword);
-  const url = 'https://facebook-data1.p.rapidapi.com/search';
+  const url = `https://${FACEBOOK_HOST}/search`;
   try {
     const res = await axios.get(url, {
       params: { query: keyword },
       headers: {
         'X-RapidAPI-Key': process.env.RAPIDAPI_KEY,
-        'X-RapidAPI-Host': 'facebook-data1.p.rapidapi.com',
+        'X-RapidAPI-Host': FACEBOOK_HOST,
       },
       timeout: 10000,
     });
@@ -62,13 +67,13 @@ async function facebookSearch(keyword) {
 
 async function youtubeSearch(keyword) {
   console.log('[RapidAPI][YouTube] request:', keyword);
-  const url = 'https://youtube-search-results.p.rapidapi.com/youtube-search';
+  const url = `https://${YOUTUBE_HOST}/youtube-search`;
   try {
     const res = await axios.get(url, {
       params: { q: keyword },
       headers: {
         'X-RapidAPI-Key': process.env.RAPIDAPI_KEY,
-        'X-RapidAPI-Host': 'youtube-search-results.p.rapidapi.com',
+        'X-RapidAPI-Host': YOUTUBE_HOST,
       },
       timeout: 10000,
     });


### PR DESCRIPTION
## Summary
- use environment variables for RapidAPI host names
- guard against non-array RapidAPI responses

## Testing
- `npm --prefix express install --silent` *(fails: ENOENT or network issues)*
- `npm --prefix express test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685423fb88488324989c4e85e0a9b888