### PR TITLE
Adjust frontend service restart policy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,6 @@ services:
     image: suzookaizokuhunter-frontend
     depends_on:
       - suzoo_express
-      - suzoo_fastapi
     ports:
       - "80:80"
       - "443:443"
@@ -103,7 +102,7 @@ services:
       - ./data/certbot/www:/var/www/certbot
     networks:
       - suzoo_net
-    restart: unless-stopped
+    restart: always
 
   suzoo_fastapi:
     container_name: suzoo_fastapi


### PR DESCRIPTION
## Summary
- change `suzoo_frontend` restart policy to `always`
- remove unnecessary dependency on `suzoo_fastapi`

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac16bec188324bf79988abf6e66b4