### PR TITLE
Fix AI_SERVICE_URL and use dev nginx config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,9 +98,7 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./nginx/production.conf:/etc/nginx/conf.d/default.conf
-      - ./data/certbot/conf:/etc/letsencrypt:ro
-      - ./data/certbot/www:/var/www/certbot
+      - ./nginx/suzoo.conf:/etc/nginx/conf.d/default.conf
     networks:
       - suzoo_net
     restart: unless-stopped
@@ -209,7 +207,7 @@ services:
       - ./api_service/uploads:/app/uploads
       - ./media_output:/app/../media_output
     environment:
-      AI_SERVICE_URL: "http://ai_service:3000"
+      AI_SERVICE_URL: "http://ai_service:5000"
     depends_on:
       - ai_service
     networks:


### PR DESCRIPTION
## Summary
- fix port mismatch for ai_service
- use development nginx config in suzoo_frontend

## Testing
- `pnpm lint`
- `pnpm build` *(fails: prettier errors)*
- `pnpm test` *(fails: missing dependencies and config)*

------
https://chatgpt.com/codex/tasks/task_e_685ac0b12d9883248c46e1be6e00742f