### PR TITLE
Integrate DMCA takedown service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -138,4 +138,5 @@ DB_CONNECT_RETRY_DELAY=5000
 ########################################
 DMCA_API_EMAIL=you@domain.com
 DMCA_API_PASSWORD=YourDmcaPassword
+DMCA_API_URL=https://api.dmca.com
 PUBLIC_HOST=https://suzookaizokuhunter.com

--- a/express/routes/infringement.js
+++ b/express/routes/infringement.js
@@ -21,7 +21,7 @@ const upload = require('../middleware/upload');
 //
 const ENGINE_MAX_LINKS = parseInt(process.env.ENGINE_MAX_LINKS, 10) || 50;
 
-// const { sendDmcaNotice } = require('../services/dmcaService');
+const { sendDmcaNotice } = require('../services/dmcaService');
 
 const JWT_SECRET = process.env.JWT_SECRET || 'KaiKaiShieldSecret';
 const TINEYE_API_KEY = process.env.TINEYE_API_KEY;
@@ -104,9 +104,11 @@ router.post('/dmca', authMiddleware, async (req, res) => {
     if (!Array.isArray(targetUrls) || !targetUrls.length) {
       return res.status(400).json({ error: '請提供 targetUrls (Array)' });
     }
-    // const result = await sendDmcaNotice(targetUrls);
-    const result = { success: true, detail: 'Mock DMCA notice sent' };
-    return res.json(result);
+    const result = await sendDmcaNotice(targetUrls);
+    if (result.success) {
+      return res.json(result);
+    }
+    return res.status(502).json({ error: result.error || 'DMCA request failed' });
   } catch (e) {
     console.error('[DMCA Error]', e);
     return res.status(500).json({ error: e.message });

--- a/express/services/dmcaService.js
+++ b/express/services/dmcaService.js
@@ -1,0 +1,42 @@
+const axios = require('axios');
+
+const DMCA_API_URL = process.env.DMCA_API_URL || 'https://api.dmca.com';
+const DMCA_API_EMAIL = process.env.DMCA_API_EMAIL;
+const DMCA_API_PASSWORD = process.env.DMCA_API_PASSWORD;
+
+if (!DMCA_API_EMAIL || !DMCA_API_PASSWORD) {
+  throw new Error('DMCA_API_EMAIL and DMCA_API_PASSWORD must be set');
+}
+
+/**
+ * Send DMCA takedown notice via DMCA.com API
+ * @param {string[]} targetUrls - infringing URLs
+ * @returns {Promise<{success: boolean, dmcaCaseId?: string, error?: string}>}
+ */
+async function sendDmcaNotice(targetUrls) {
+  try {
+    const loginRes = await axios.post(`${DMCA_API_URL}/login`, {
+      email: DMCA_API_EMAIL,
+      password: DMCA_API_PASSWORD,
+    }, { timeout: 15000 });
+    const token = loginRes.data?.token;
+    if (!token) throw new Error('Login failed: missing token');
+
+    const res = await axios.post(
+      `${DMCA_API_URL}/takedowns`,
+      { links: targetUrls },
+      { headers: { Authorization: `Bearer ${token}` }, timeout: 15000 }
+    );
+    const dmcaCaseId = res.data?.caseId || res.data?.id;
+    if (!dmcaCaseId) throw new Error('DMCA API response missing caseId');
+    return { success: true, dmcaCaseId };
+  } catch (err) {
+    const status = err.response?.status || 'N/A';
+    const message = err.response?.data ? JSON.stringify(err.response.data) : err.message;
+    const errorMsg = `DMCA API request failed with status ${status}. ${message}`;
+    console.error('[dmcaService] error:', errorMsg);
+    return { success: false, error: errorMsg };
+  }
+}
+
+module.exports = { sendDmcaNotice };


### PR DESCRIPTION
## Summary
- add new `dmcaService` using DMCA.com API
- wire DMCA service into infringement route
- document `DMCA_API_URL` in `.env.example`

## Testing
- `pnpm test` *(fails: sharp install and missing credentials)*

------
https://chatgpt.com/codex/tasks/task_e_685b5d527a288324999c29862739726b