### PR TITLE
Fix Milvus image tag

### DIFF
--- a/.env
+++ b/.env
@@ -94,6 +94,7 @@ EXPRESS_PORT=3000
 ########################################
 MILVUS_HOST=suzoo_milvus
 MILVUS_PORT=19530
+MILVUS_IMAGE_TAG=v2.4.4-20240531-8e7f36d9-amd64
 
 ########################################
 # RabbitMQ / Celery

--- a/.env.example
+++ b/.env.example
@@ -100,6 +100,7 @@ EXPRESS_PORT=3000
 ########################################
 MILVUS_HOST=suzoo_milvus
 MILVUS_PORT=19530
+MILVUS_IMAGE_TAG=v2.4.4-20240531-8e7f36d9-amd64
 
 ########################################
 # RabbitMQ / Celery (可調整)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,7 @@ services:
     logging: *default-logging
 
   milvus:
-    image: milvusdb/milvus:v2.4.4-cpu
+    image: milvusdb/milvus:${MILVUS_IMAGE_TAG:-v2.4.4-20240531-8e7f36d9-amd64}
     container_name: suzoo_milvus
     restart: always
     networks:


### PR DESCRIPTION
## Summary
- fix docker-compose Milvus image tag so startup succeeds
- expose `MILVUS_IMAGE_TAG` environment variable in `.env` and `.env.example`

## Testing
- `npm test` *(fails: turbo not found)*
- `npx turbo run test` *(interactive install prompt; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_685bfe520dac8324b91a6fb63851f1e6