### PR TITLE
Use env vars for admin user

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,13 @@ EXPRESS_LOGIN_PASS=your_express_password
 EXPRESS_BASE_URL=http://suzoo_express:3000
 
 ########################################
+# Default Admin Account
+########################################
+ADMIN_EMAIL=admin@example.com
+ADMIN_PHONE=0900000000
+ADMIN_PASS=ChangeMe123!
+
+########################################
 # Sequelize / Postgres 連線 (優先)
 ########################################
 DATABASE_URL=postgresql://suzoo:KaiShieldDbPass2023!@suzoo_postgres:5432/suzoo

--- a/check_infringement.sh
+++ b/check_infringement.sh
@@ -2,9 +2,9 @@
 set -euo pipefail
 
 # ─── 1. 登录取得 JWT ─────────────────────────────────────
-# 如果你改过 /auth/login 的账号/密码，请在这里替换
-LOGIN_EMAIL="jeffqqm@gmail.com"
-LOGIN_PASS="Zack967988"
+# 如果你改過 /auth/login 的帳號/密碼，請在這裡設定
+LOGIN_EMAIL="${ADMIN_EMAIL:-admin@example.com}"
+LOGIN_PASS="${ADMIN_PASS:-ChangeMe123!}"
 
 LOGIN_RES=$(curl -s -X POST http://localhost:3000/auth/login \
   -H "Content-Type: application/json" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,10 @@ services:
       - "3000:3000"
     env_file:
       - .env
+    environment:
+      - ADMIN_EMAIL=${ADMIN_EMAIL}
+      - ADMIN_PHONE=${ADMIN_PHONE}
+      - ADMIN_PASS=${ADMIN_PASS}
     volumes:
       - ./express:/app
       - /app/node_modules

--- a/express/createDefaultAdmin.js
+++ b/express/createDefaultAdmin.js
@@ -10,9 +10,14 @@ const { User } = require('./models');
 
 module.exports = async function createDefaultAdmin() {
   try {
-    const defaultEmail = 'jeffqqm@gmail.com';
-    const defaultPhone = '0900296168';
-    const defaultPass = 'Zack967988';
+    const defaultEmail = process.env.ADMIN_EMAIL;
+    const defaultPhone = process.env.ADMIN_PHONE;
+    const defaultPass = process.env.ADMIN_PASS;
+
+    if (!defaultEmail || !defaultPhone || !defaultPass) {
+      console.error('[InitAdmin] ADMIN_* environment variables are required');
+      return;
+    }
 
     // 查找相同 email or phone 的使用者
     const existing = await User.findOne({


### PR DESCRIPTION
## Summary
- read admin credentials from environment variables in Express
- document admin credentials in `.env.example`
- pass admin credentials via `docker-compose.yml`
- read admin credentials in `check_infringement.sh`

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c2d9ac7008324bf7d0f17254fda69