### PR TITLE
Unify blockchain RPC config

### DIFF
--- a/.env
+++ b/.env
@@ -35,7 +35,7 @@ INSTAGRAM_HOST=instagram-scrapper-posts-reels-stories-downloader.p.rapidapi.com
 YOUTUBE_HOST=youtube138.p.rapidapi.com
 
 ########################################
-# Ganache RPC URL & Private Key
+# Blockchain RPC URL & Private Key
 ########################################
 BLOCKCHAIN_RPC_URL=http://suzoo_ganache:8545
 BLOCKCHAIN_PRIVATE_KEY=0xc3ded7eaec361d5b94a495e390be497a7fd54173e6ca6f77df071b22cb7bd4d1

--- a/.env.example
+++ b/.env.example
@@ -45,7 +45,7 @@ INSTAGRAM_HOST=instagram-scrapper-posts-reels-stories-downloader.p.rapidapi.com
 YOUTUBE_HOST=youtube138.p.rapidapi.com
 
 ########################################
-# Ganache RPC URL & Private Key
+# Blockchain RPC URL & Private Key
 ########################################
 BLOCKCHAIN_RPC_URL=http://suzoo_ganache:8545
 BLOCKCHAIN_PRIVATE_KEY=0xc3ded7eaec361d5b94a495e390be497a7fd54173e6ca6f77df071b22cb7bd4d1

--- a/express/routes/blockchain.js
+++ b/express/routes/blockchain.js
@@ -2,9 +2,9 @@
 const Web3 = require('web3'); 
 // or ethers, or any library you prefer
 
-// 假設您有 ganache URL
-const GANACHE_URL = process.env.GANACHE_URL || 'http://ganache:8545';
-const web3 = new Web3(new Web3.providers.HttpProvider(GANACHE_URL));
+// 假設您有區塊鏈 RPC URL
+const BLOCKCHAIN_RPC_URL = process.env.BLOCKCHAIN_RPC_URL || 'http://ganache:8545';
+const web3 = new Web3(new Web3.providers.HttpProvider(BLOCKCHAIN_RPC_URL));
 
 // TODO: 如果需要合約位址 / 私鑰 / abi
 const CONTRACT_ADDRESS = process.env.CONTRACT_ADDRESS;

--- a/fastapi/main.py
+++ b/fastapi/main.py
@@ -38,7 +38,7 @@ CLOUD_API_SECRET = os.getenv("CLOUDINARY_API_SECRET")
 # 需改成 /dns4/ + /tcp/ + /http
 IPFS_API_URL = "/dns4/suzoo_ipfs/tcp/5001/http"
 
-GANACHE_URL = os.getenv("GANACHE_URL", "http://suzoo_ganache:8545")
+BLOCKCHAIN_RPC_URL = os.getenv("BLOCKCHAIN_RPC_URL", "http://suzoo_ganache:8545")
 GANACHE_PRIV_KEY = os.getenv("GANACHE_PRIVATE_KEY", "")
 CONTRACT_ADDR = os.getenv("CONTRACT_ADDRESS", "")
 
@@ -65,13 +65,13 @@ cloudinary.config(
 )
 
 # === Web3 (Ganache)
-w3 = Web3(Web3.HTTPProvider(GANACHE_URL))
+w3 = Web3(Web3.HTTPProvider(BLOCKCHAIN_RPC_URL))
 
 # 改用 w3.isConnected() 以相容舊版 Web3
 if w3.isConnected():
-    print("[FastAPI] Ganache connected at", GANACHE_URL)
+    print("[FastAPI] Ganache connected at", BLOCKCHAIN_RPC_URL)
 else:
-    print("[FastAPI] Ganache not connected:", GANACHE_URL)
+    print("[FastAPI] Ganache not connected:", BLOCKCHAIN_RPC_URL)
 
 # 預設合約 ABI
 contract = None


### PR DESCRIPTION
## Summary
- replace `GANACHE_URL` with `BLOCKCHAIN_RPC_URL` in FastAPI service
- read `BLOCKCHAIN_RPC_URL` in Express blockchain route
- document unified variable in `.env.example`
- update local `.env` comments for clarity

## Testing
- `pnpm dlx turbo run test` *(fails: could not resolve workspaces)*

------
https://chatgpt.com/codex/tasks/task_e_685c2d9920f48324be5f21c8734f36f6