### PR TITLE
Fix nginx config path

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -27,7 +27,7 @@ FROM nginx:alpine
 COPY --from=builder /app/build /usr/share/nginx/html
 
 # 若要自訂 nginx conf（建議），請取消下一行註解並提供檔案
-# COPY nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY suzoo.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 


### PR DESCRIPTION
## Summary
- use suzoo.conf in frontend Dockerfile

## Testing
- `npm test` *(fails: `sh: 1: turbo: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c30e20df48324a6d9e30376eccb27