### PR TITLE
Update nginx config for suzoo_frontend

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -27,7 +27,7 @@ FROM nginx:alpine
 COPY --from=builder /app/build /usr/share/nginx/html
 
 # 若要自訂 nginx conf（建議），請取消下一行註解並提供檔案
-# COPY nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY suzoo.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 


### PR DESCRIPTION
## Summary
- use `suzoo.conf` as the default nginx config in the frontend Docker image

## Testing
- `docker compose build suzoo_frontend` *(fails: docker not found)*


------
https://chatgpt.com/codex/tasks/task_e_685c31884d00832490a245ae4320373c