### PR TITLE
Add FastAPI service and update nginx routing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - suzoo-network
     depends_on:
       - suzoo_express
+      - suzoo_fastapi
     restart: always
     logging: &default-logging
       driver: "json-file"
@@ -68,6 +69,30 @@ services:
         condition: service_started
     networks:
       - suzoo-network
+    restart: always
+    logging: *default-logging
+
+  # -------------------------------------
+  # AI/ML 後端服務 (Python/FastAPI)
+  # -------------------------------------
+  suzoo_fastapi:
+    container_name: suzoo_fastapi
+    build:
+      context: ./fastapi
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    volumes:
+      - ./fastapi:/app
+    networks:
+      - suzoo-network
+    depends_on:
+      - suzoo_postgres
+      - milvus
+      - suzoo_ipfs
+      - suzoo_ganache
     restart: always
     logging: *default-logging
 

--- a/frontend/nginx/default.conf
+++ b/frontend/nginx/default.conf
@@ -1,16 +1,41 @@
+# /frontend/nginx/default.conf (v2.0 - 智能路由版)
+# 描述:
+# - 作為整個系統的流量入口。
+# - 根據請求路徑，智能地將請求代理到 Express 或 FastAPI 後端。
+
 server {
     listen 80;
     server_name _;
     root /usr/share/nginx/html;
+    index index.html index.htm;
 
-    location / {
-        try_files $uri /index.html;
+    client_max_body_size 100M;
+
+    # 規則 (1): /api/v1/ -> 代理給 FastAPI 服務
+    location /api/v1/ {
+        proxy_pass http://suzoo_fastapi:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # 將 API Proxy（若前端直接呼叫 /api）導向後端 container
+    # 規則 (2): /api/ -> 代理給 Express 服務
     location /api/ {
         proxy_pass http://suzoo_express:3000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # 規則 (3): 其他路由 -> 前端 SPA
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location ~* \.(css|js|jpg|jpeg|png|gif|ico|svg)$ {
+        expires 1y;
+        add_header Cache-Control "public";
     }
 }


### PR DESCRIPTION
## Summary
- add `suzoo_fastapi` service to docker-compose
- route frontend requests via nginx to FastAPI or Express as appropriate

## Testing
- `pnpm lint` *(fails: turbo not found)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ca584cc3883248be844f5b937fc6b