### PR TITLE
Add scan route and fix RapidAPI host vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ TINEYE_API_KEY=your_tineye_api_key
 }
 ```
 
+### GET `/api/protect/scan/:fileId`
+
+* 與 Step2 功能相同，提供以路由參數觸發完整掃描的方式
+
+
 ## Protect API Routes
 
 Express 服務在 `/api/protect` 下提供上述端點，前端在完成上傳後即可依據 `fileId` 呼叫 Step2。

--- a/express/services/rapidApi.service.js
+++ b/express/services/rapidApi.service.js
@@ -3,6 +3,8 @@ const logger = require('../utils/logger');
 
 const TIKTOK_HOST = process.env.TIKTOK_HOST;
 const YOUTUBE_HOST = process.env.YOUTUBE_HOST;
+const INSTAGRAM_HOST = process.env.INSTAGRAM_HOST;
+const FACEBOOK_HOST = process.env.FACEBOOK_HOST;
 const RAPIDAPI_KEY = process.env.RAPIDAPI_KEY;
 
 function extractLinks(data, platform) {


### PR DESCRIPTION
## Summary
- add `/api/protect/scan/:fileId` route for full scan
- refactor scan logic into `handleScan`
- include `INSTAGRAM_HOST` and `FACEBOOK_HOST` env vars in RapidAPI service
- document new endpoint in README

## Testing
- `npm test` *(fails: turbo not found)*
- `docker compose down` *(fails: command not found)*
- `docker compose up -d --build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cb504549c8324bed976bd0f379a5a