### PR TITLE
Fix IPFS service buffer

### DIFF
--- a/express/services/ipfsService.js
+++ b/express/services/ipfsService.js
@@ -41,7 +41,8 @@ async function getFile(cid) {
     for await (const chunk of client.cat(cid)) {
       chunks.push(chunk);
     }
-    const buffer = uint8ArrayConcat(chunks);
+    const uint8Buffer = uint8ArrayConcat(chunks);
+    const buffer = Buffer.from(uint8Buffer);
     logger.info(`[ipfsService.getFile] Successfully fetched ${buffer.length} bytes for CID: ${cid}`);
     return buffer;
   } catch (err) {


### PR DESCRIPTION
## Summary
- ensure `ipfsService.getFile` returns a Node `Buffer`

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d6377d374832496d2211141cd5e69