### PR TITLE
Fix storing scan results as JSON string

### DIFF
--- a/express/routes/protect.js
+++ b/express/routes/protect.js
@@ -160,7 +160,7 @@ router.post('/step2', async (req, res) => {
         const finalResults = { ...scanResults, internalMatches: vectorMatches };
 
         file.status = 'scanned';
-        file.resultJson = finalResults;
+        file.resultJson = JSON.stringify(finalResults);
         await file.save();
 
         const reportFileName = `report_${fileId}_${Date.now()}.pdf`;
@@ -213,7 +213,7 @@ router.get('/scan/:fileId', async (req, res) => {
 
         const finalResults = { ...scanResults, internalMatches: vectorMatches };
         file.status = 'scanned';
-        file.resultJson = finalResults;
+        file.resultJson = JSON.stringify(finalResults);
         await file.save();
         logger.info(`[Scan Route] Scan results saved to database.`);
 


### PR DESCRIPTION
## Summary
- store `finalResults` as a JSON string in Express protect routes

## Testing
- `npm install` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_685d7654a1508324bcf2eb470659d2d4