### PR TITLE
Fix TinEye integration and update Step3 handling

### DIFF
--- a/express/routes/protect.js
+++ b/express/routes/protect.js
@@ -167,8 +167,22 @@ router.post('/step2', async (req, res) => {
         const reportPath = path.join(REPORTS_DIR, reportFileName);
         const reportUrl = `${process.env.PUBLIC_HOST}/uploads/reports/${reportFileName}`;
 
+        const suspiciousLinks = [
+            ...(finalResults.imageSearch?.googleVision?.links || []),
+            ...((finalResults.imageSearch?.tineye?.matches || []).map(m => m.url))
+        ];
+
         process.nextTick(() => {
-            generateScanPDFWithMatches(file.id, reportPath, finalResults)
+            generateScanPDFWithMatches({
+                file: {
+                    id: file.id,
+                    filename: file.filename,
+                    fingerprint: file.fingerprint,
+                    status: file.status,
+                },
+                suspiciousLinks,
+                matchedImages: vectorMatches,
+            }, reportPath)
                .then(() => file.update({ report_url: reportUrl }))
                .catch(err => logger.error(`[Step2] Failed to generate or save report for File ID: ${fileId}`, err));
         });
@@ -221,8 +235,22 @@ router.get('/scan/:fileId', async (req, res) => {
         const reportPath = path.join(REPORTS_DIR, reportFileName);
         const reportUrl = `${process.env.PUBLIC_HOST}/uploads/reports/${reportFileName}`;
 
+        const suspiciousLinks = [
+            ...(finalResults.imageSearch?.googleVision?.links || []),
+            ...((finalResults.imageSearch?.tineye?.matches || []).map(m => m.url))
+        ];
+
         process.nextTick(() => {
-            generateScanPDFWithMatches(file.id, reportPath, finalResults)
+            generateScanPDFWithMatches({
+                file: {
+                    id: file.id,
+                    filename: file.filename,
+                    fingerprint: file.fingerprint,
+                    status: file.status,
+                },
+                suspiciousLinks,
+                matchedImages: vectorMatches,
+            }, reportPath)
                .then(() => file.update({ report_url: reportUrl }))
                .then(() => logger.info(`[Scan Route] Report generated and URL updated for File ID: ${fileId}`))
                .catch(err => logger.error(`[Scan Route] Failed to generate or save report for File ID: ${fileId}`, err));

--- a/express/routes/searchRoutes.js
+++ b/express/routes/searchRoutes.js
@@ -19,11 +19,9 @@ router.post('/search/tineye', upload.single('file'), async (req, res) => {
       return res.status(400).json({ error: 'file required' });
     }
 
-    const tmpPath = path.join(require('os').tmpdir(), `tineye_${Date.now()}.jpg`);
-    await fs.promises.writeFile(tmpPath, req.file.buffer);
-    const result = await tineyeService.searchByFile(tmpPath);
-    await fs.promises.unlink(tmpPath).catch(() => {});
-    return res.json({ matches: result.links || [] });
+    // TinEye service now accepts buffers directly
+    const result = await tineyeService.searchByBuffer(req.file.buffer);
+    return res.json({ matches: result.matches || [] });
   } catch (err) {
     console.error('[POST /api/search/tineye] error =>', err.message || err);
     return res.status(500).json({ error: err.message || 'TinEye search failed' });

--- a/express/services/vision.service.js
+++ b/express/services/vision.service.js
@@ -39,20 +39,8 @@ async function infringementScan(buffer) {
         throw new Error('Image buffer is required for infringement scan');
     }
 
-    const tmpDir = path.join(os.tmpdir(), 'vision-infr');
-    await fs.mkdir(tmpDir, { recursive: true });
-    const tmpPath = path.join(tmpDir, `img_${Date.now()}.jpg`);
-
-    await fs.writeFile(tmpPath, buffer);
-
-    let tineyeResult;
-    try {
-        tineyeResult = await tinEyeService.searchByFile(tmpPath);
-    } finally {
-        await fs.unlink(tmpPath).catch(err =>
-            logger.warn(`[Vision Service] Failed to delete temp file ${tmpPath}: ${err.message}`)
-        );
-    }
+    // Directly send the buffer to TinEye instead of writing a temp file
+    const tineyeResult = await tinEyeService.searchByBuffer(buffer);
 
     const visionResult = await searchByBuffer(buffer);
 

--- a/frontend/src/pages/ProtectStep3.jsx
+++ b/frontend/src/pages/ProtectStep3.jsx
@@ -149,7 +149,6 @@ export default function ProtectStep3() {
       }
 
       setScanResult(data.results);
-      // 將掃描結果存入 localStorage，以便 Step 4 使用
       localStorage.setItem('protectStep3', JSON.stringify({ scanResults: data.results }));
 
     } catch (err) {
@@ -166,9 +165,15 @@ export default function ProtectStep3() {
 
   const handleGoStep4 = () => {
     if (scanResult) {
-      // 使用 navigate state 將複雜資料傳遞到下一頁
-      navigate('/protect/step4-infringement', { 
-        state: { ...step1Data, scanResults: scanResult } 
+      const googleLinks = scanResult.imageSearch?.googleVision?.links || [];
+      const tineyeLinks = (scanResult.imageSearch?.tineye?.matches || []).map(m => m.url);
+      const suspiciousLinks = [...googleLinks, ...tineyeLinks];
+      navigate('/protect/step4-infringement', {
+        state: {
+          ...step1Data,
+          scanResults: scanResult,
+          suspiciousLinks
+        }
       });
     }
   };
@@ -189,12 +194,9 @@ export default function ProtectStep3() {
     }
 
     if (scanResult) {
-      const allLinks = [
-          ...(scanResult.google || []),
-          ...(scanResult.tineye || []),
-          ...(scanResult.yandex || []),
-          // ... 其他平台的結果
-      ];
+      const googleLinks = (scanResult.imageSearch?.googleVision?.links || []).map(url => ({ source: 'Google Vision', url }));
+      const tineyeLinks = (scanResult.imageSearch?.tineye?.matches || []).map(m => ({ source: 'TinEye', url: m.url }));
+      const allLinks = [...googleLinks, ...tineyeLinks];
 
       return (
         <InfoBlock>


### PR DESCRIPTION
## Summary
- update TinEye calls to use buffer-based API
- generate PDF reports using structured params
- adjust React step to parse new backend response

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d7e3454dc8324a1bf8619de15b35f