### PR TITLE
Fix vision credentials mount and array safety

### DIFF
--- a/credentials/gcp-vision.json.example
+++ b/credentials/gcp-vision.json.example
@@ -1,0 +1,1 @@
+{"example":"credentials"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@ services:
       - ./express:/app
       - /app/node_modules
       - ./uploads:/app/uploads
+      - ./credentials:/app/credentials:ro
       - /etc/letsencrypt:/etc/letsencrypt:ro
     depends_on:
       suzoo_postgres:

--- a/express/services/tineye.service.js
+++ b/express/services/tineye.service.js
@@ -29,7 +29,13 @@ async function searchByBuffer(buffer) {
             },
         });
 
-        const results = response.data.results.matches.map(match => ({
+        const matches = Array.isArray(response.data?.results?.matches)
+            ? response.data.results.matches
+            : [];
+        if (!Array.isArray(response.data?.results?.matches)) {
+            logger.warn('[TinEye Service] matches is not array:', response.data?.results?.matches);
+        }
+        const results = matches.map(match => ({
             url: match.image_url,
             type: 'Match',
             source: 'TinEye',

--- a/express/services/vision.service.js
+++ b/express/services/vision.service.js
@@ -19,8 +19,10 @@ async function searchByBuffer(buffer) {
         const [result] = await visionClient.webDetection({ image: { content: buffer } });
         const webDetection = result.webDetection;
         let urls = [];
-        if (webDetection && webDetection.pagesWithMatchingImages) {
+        if (Array.isArray(webDetection?.pagesWithMatchingImages)) {
             urls = webDetection.pagesWithMatchingImages.map(page => page.url).filter(Boolean);
+        } else if (webDetection && webDetection.pagesWithMatchingImages) {
+            logger.warn('[Vision Service] pagesWithMatchingImages is not array:', webDetection.pagesWithMatchingImages);
         }
         const uniqueUrls = [...new Set(urls)].slice(0, VISION_MAX_RESULTS);
         logger.info(`[Vision Service] Search by buffer successful, found ${uniqueUrls.length} links.`);

--- a/frontend/src/pages/ProtectStep3.jsx
+++ b/frontend/src/pages/ProtectStep3.jsx
@@ -165,8 +165,13 @@ export default function ProtectStep3() {
 
   const handleGoStep4 = () => {
     if (scanResult) {
-      const googleLinks = scanResult.imageSearch?.googleVision?.links || [];
-      const tineyeLinks = (scanResult.imageSearch?.tineye?.matches || []).map(m => m.url);
+      const googleLinks = Array.isArray(scanResult.imageSearch?.googleVision?.links)
+        ? scanResult.imageSearch.googleVision.links
+        : [];
+      const tineyeMatches = Array.isArray(scanResult.imageSearch?.tineye?.matches)
+        ? scanResult.imageSearch.tineye.matches
+        : [];
+      const tineyeLinks = tineyeMatches.map(m => m.url);
       const suspiciousLinks = [...googleLinks, ...tineyeLinks];
       navigate('/protect/step4-infringement', {
         state: {
@@ -194,8 +199,12 @@ export default function ProtectStep3() {
     }
 
     if (scanResult) {
-      const googleLinks = (scanResult.imageSearch?.googleVision?.links || []).map(url => ({ source: 'Google Vision', url }));
-      const tineyeLinks = (scanResult.imageSearch?.tineye?.matches || []).map(m => ({ source: 'TinEye', url: m.url }));
+      const googleLinks = Array.isArray(scanResult.imageSearch?.googleVision?.links)
+        ? scanResult.imageSearch.googleVision.links.map(url => ({ source: 'Google Vision', url }))
+        : [];
+      const tineyeLinks = Array.isArray(scanResult.imageSearch?.tineye?.matches)
+        ? scanResult.imageSearch.tineye.matches.map(m => ({ source: 'TinEye', url: m.url }))
+        : [];
       const allLinks = [...googleLinks, ...tineyeLinks];
 
       return (

--- a/frontend/src/pages/ProtectStep4Infringement.jsx
+++ b/frontend/src/pages/ProtectStep4Infringement.jsx
@@ -96,10 +96,11 @@ export default function ProtectStep4Infringement() {
     fingerprint,
     ipfsHash,
     txHash,
-    suspiciousLinks = [],
+    suspiciousLinks: rawLinks = [],
     // ★ 後端回傳的 PDF 連結 (可直接打開/下載)
     scanReportUrl
   } = info;
+  const suspiciousLinks = Array.isArray(rawLinks) ? rawLinks : [];
 
   /**
    * 直接下載 PDF


### PR DESCRIPTION
## Summary
- mount `./credentials` directory in docker-compose so express can access vision key
- add example `credentials/gcp-vision.json.example`
- safeguard TinEye and Google Vision services when returned structures aren't arrays
- make front‑end steps tolerant of unexpected data types

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d82b7535483249d071a3194acc339