### PR TITLE
Add healthcheck endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,8 +108,8 @@ services:
       milvus:
         condition: service_started
     healthcheck:
-      # 【關鍵修正】改用 wget 進行健康檢查，它比 curl 更通用
-      test: ["CMD", "wget", "--no-verbose", "--spider", "--fail", "http://localhost:8000/docs"]
+      # Use a dedicated health endpoint instead of the docs page
+      test: ["CMD", "wget", "--no-verbose", "--spider", "--fail", "http://localhost:8000/healthz"]
       interval: 15s
       timeout: 5s
       retries: 5

--- a/fastapi/main.py
+++ b/fastapi/main.py
@@ -167,6 +167,11 @@ def generate_pdf_certificate(username, fingerprint, ipfs_cid, cloud_url, tx_hash
 def health():
     return {"status": "fastapi OK"}
 
+# Dedicated healthcheck endpoint for container probes
+@app.get("/healthz")
+def healthz():
+    return {"status": "ok"}
+
 @app.post("/api/upload")
 async def upload_file(file: UploadFile = File(...), authorization: str = Header(None)):
     """上傳檔案 => IPFS => Cloudinary => Ganache => PDF => DB"""


### PR DESCRIPTION
## Summary
- add new `/healthz` route for container checks
- point FastAPI healthcheck to `/healthz` in compose

## Testing
- `pnpm test` *(fails: vision tests require external dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685e3b35bbec83248706b84394a3e411