### PR TITLE
Fix TinEye results processing

### DIFF
--- a/express/services/tineye.service.js
+++ b/express/services/tineye.service.js
@@ -39,7 +39,9 @@ async function searchByBuffer(buffer) {
             url: match.image_url,
             type: 'Match',
             source: 'TinEye',
-            backlinks: match.backlinks.map(link => link.url)
+            backlinks: Array.isArray(match.backlinks)
+                ? match.backlinks.map(link => link.url)
+                : []
         }));
 
         logger.info(`[TinEye Service] Search complete. Found ${results.length} matches.`);


### PR DESCRIPTION
## Summary
- guard against missing `backlinks` field when processing TinEye search results

## Testing
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e426f90b88324b6d81ed03b16fd1f