### PR TITLE
Fix API endpoints for vector search and RapidAPI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,7 +129,8 @@ AWS_REGION=us-east-1
 ########################################
 # 向量服務 URL
 ########################################
-VECTOR_SERVICE_URL=http://suzoo_python_vector:8000
+# Updated container name
+VECTOR_SERVICE_URL=http://suzoo_fastapi:8000
 
 ########################################
 # Google Cloud Vision

--- a/express/services/rapidApi.service.js
+++ b/express/services/rapidApi.service.js
@@ -55,12 +55,19 @@ const youtubeSearch = (keyword) => makeRequest('YouTube', {
     method: 'GET', url: `https://${YOUTUBE_HOST}/search`, params: { q: keyword, maxResults: '10' }, headers: { 'X-RapidAPI-Key': RAPIDAPI_KEY, 'X-RapidAPI-Host': YOUTUBE_HOST }
 });
 
+// Some RapidAPI providers use '/search' rather than '/search/posts'
 const instagramSearch = (keyword) => makeRequest('Instagram', {
-    method: 'GET', url: `https://${INSTAGRAM_HOST}/search/posts`, params: { query: keyword, count: '10' }, headers: { 'X-RapidAPI-Key': RAPIDAPI_KEY, 'X-RapidAPI-Host': INSTAGRAM_HOST }
+    method: 'GET',
+    url: `https://${INSTAGRAM_HOST}/search`,
+    params: { query: keyword, count: '10' },
+    headers: { 'X-RapidAPI-Key': RAPIDAPI_KEY, 'X-RapidAPI-Host': INSTAGRAM_HOST }
 });
 
 const facebookSearch = (keyword) => makeRequest('Facebook', {
-    method: 'GET', url: `https://${FACEBOOK_HOST}/search/posts`, params: { q: keyword, limit: '10' }, headers: { 'X-RapidAPI-Key': RAPIDAPI_KEY, 'X-RapidAPI-Host': FACEBOOK_HOST }
+    method: 'GET',
+    url: `https://${FACEBOOK_HOST}/search`,
+    params: { q: keyword, limit: '10' },
+    headers: { 'X-RapidAPI-Key': RAPIDAPI_KEY, 'X-RapidAPI-Host': FACEBOOK_HOST }
 });
 
 module.exports = { tiktokSearch, youtubeSearch, instagramSearch, facebookSearch };

--- a/express/utils/vectorSearch.js
+++ b/express/utils/vectorSearch.js
@@ -7,8 +7,9 @@ const os = require('os');
 const logger = require('./logger');
 
 const VECTOR_SERVICE_URL = process.env.VECTOR_SERVICE_URL;
-const INDEX_ENDPOINT = `${VECTOR_SERVICE_URL}/index-image`;
-const SEARCH_ENDPOINT = `${VECTOR_SERVICE_URL}/search-image`;
+// Align with the FastAPI service routes
+const INDEX_ENDPOINT = `${VECTOR_SERVICE_URL}/api/v1/image-insert`;
+const SEARCH_ENDPOINT = `${VECTOR_SERVICE_URL}/api/v1/image-search`;
 
 /**
  * 【修正】發送圖片 Buffer 到 Python 服務進行索引。


### PR DESCRIPTION
## Summary
- align vector service URLs with FastAPI endpoints
- correct RapidAPI Instagram/Facebook endpoint paths
- update sample env to use current container name

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e51836ee483248ab1210bcb063484