### PR TITLE
Fix Puppeteer link extraction

### DIFF
--- a/express/services/aggregatorSearchLink.js
+++ b/express/services/aggregatorSearchLink.js
@@ -195,7 +195,7 @@ async function aggregatorSearchGinifabStrict(localFilePath='', publicImageUrl=''
         }
 
         // 抓取 popup 裡不含 ginifab/bing/tineye/baidu.com 的連結
-        let hrefs = await popup.$$eval('a', as=> as.map(a=> a.href));
+        let hrefs = await popup.$$eval('a', as => Array.from(as).map(a => a.href));
         hrefs = hrefs.filter(link =>
           link && !link.includes('ginifab') &&
           !link.includes('bing.com') &&

--- a/express/services/ginifabEngine.js
+++ b/express/services/ginifabEngine.js
@@ -36,7 +36,7 @@ async function fallbackDirectEngines(imagePath) {
         await fileInput.uploadFile(imagePath);
         await page.waitForTimeout(5000);
 
-        let links = await page.$$eval('a', as=> as.map(a=> a.href));
+        let links = await page.$$eval('a', as => Array.from(as).map(a => a.href));
         links = links.filter(x=> x && !x.includes('bing.com'));
         results.bing.push(...links.slice(0, ENGINE_MAX_LINKS));
       }
@@ -57,7 +57,7 @@ async function fallbackDirectEngines(imagePath) {
         await page.waitForNavigation({ waitUntil:'domcontentloaded', timeout:20000 }).catch(()=>{});
         await page.waitForTimeout(3000);
 
-        let links = await page.$$eval('a', as=> as.map(a=> a.href));
+        let links = await page.$$eval('a', as => Array.from(as).map(a => a.href));
         links = links.filter(x=> x && !x.includes('tineye.com'));
         results.tineye.push(...links.slice(0, ENGINE_MAX_LINKS));
       }
@@ -77,7 +77,7 @@ async function fallbackDirectEngines(imagePath) {
         await fileInput.uploadFile(imagePath);
         await page.waitForTimeout(5000);
 
-        let links = await page.$$eval('a', as=> as.map(a=> a.href));
+        let links = await page.$$eval('a', as => Array.from(as).map(a => a.href));
         links = links.filter(x=> x && !x.includes('baidu.com'));
         results.baidu.push(...links.slice(0, ENGINE_MAX_LINKS));
       }
@@ -261,7 +261,7 @@ async function aggregatorSearchGinifab(localFilePath, aggregatorImageUrl) {
         }
 
         // 擷取該 popup 頁面上的連結
-        let hrefs = await popup.$$eval('a', as => as.map(a=>a.href));
+        let hrefs = await popup.$$eval('a', as => Array.from(as).map(a => a.href));
         // 過濾掉 aggregator / 自家 domain
         hrefs = hrefs.filter(link=>{
           if(!link) return false;

--- a/express/utils/aggregatorSearchGinifab.js
+++ b/express/utils/aggregatorSearchGinifab.js
@@ -271,7 +271,7 @@ async function aggregatorSearchGinifab(browser, localImagePath, publicImageUrl) 
         await popupPage.waitForTimeout(3000);
 
         // 擷取連結 (過濾 ginifab / bing.com / tineye.com / baidu.com 自己)
-        let hrefs = await popupPage.$$eval('a', as => as.map(a => a.href));
+        let hrefs = await popupPage.$$eval('a', as => Array.from(as).map(a => a.href));
         hrefs = hrefs.filter(h =>
           h && !h.includes('ginifab.com') &&
           !h.includes('bing.com') &&

--- a/express/utils/doSearchEngines.js
+++ b/express/utils/doSearchEngines.js
@@ -224,7 +224,7 @@ async function clickEngineAndGetLinks(ginifabPage, browser, engine) {
   }
 
   // 抓所有超連結 -> 過濾 ginifab / 自身域名
-  let hrefs = await popup.$$eval('a', as=> as.map(a=> a.href));
+  let hrefs = await popup.$$eval('a', as => Array.from(as).map(a => a.href));
   const excludes= ['ginifab','bing.com','tineye.com','baidu.com'];
   hrefs = hrefs.filter(link => 
     link && !excludes.some(ex => link.includes(ex))

--- a/express/utils/multiEngineReverseImage.js
+++ b/express/utils/multiEngineReverseImage.js
@@ -44,7 +44,7 @@ async function doMultiReverseImage(imagePath, fileId) {
       await page.waitForNavigation({ waitUntil:'domcontentloaded', timeout:15000 }).catch(()=>{});
       await page.waitForTimeout(3000);
 
-      let links = await page.$$eval('a', as => as.map(a=>a.href));
+      let links = await page.$$eval('a', as => Array.from(as).map(a => a.href));
       foundLinks = links.filter(l => l && !l.includes('bing.com'));
       if(!foundLinks.length){
         await page.screenshot({ path: `uploads/bing_search_${fileId}_noresult.png` }).catch(()=>{});
@@ -69,7 +69,7 @@ async function doMultiReverseImage(imagePath, fileId) {
       await page.waitForNavigation({ waitUntil:'domcontentloaded', timeout:15000 }).catch(()=>{});
       await page.waitForTimeout(3000);
 
-      let links = await page.$$eval('a', as => as.map(a=>a.href));
+      let links = await page.$$eval('a', as => Array.from(as).map(a => a.href));
       foundLinks = links.filter(l => l && !l.includes('tineye.com'));
       if(!foundLinks.length){
         await page.screenshot({ path:`uploads/tineye_search_${fileId}_noresult.png` }).catch(()=>{});
@@ -96,7 +96,7 @@ async function doMultiReverseImage(imagePath, fileId) {
       await fileInput.uploadFile(imagePath);
       await page.waitForTimeout(5000);
 
-      let links = await page.$$eval('a', as => as.map(a=>a.href));
+      let links = await page.$$eval('a', as => Array.from(as).map(a => a.href));
       foundLinks = links.filter(l => l && !l.includes('baidu.com'));
       if(!foundLinks.length){
         await page.screenshot({ path:`uploads/baidu_search_${fileId}_noresult.png` }).catch(()=>{});


### PR DESCRIPTION
## Summary
- fix Puppeteer link scraping to always use `Array.from()` when mapping node lists

## Testing
- `npm test` *(fails: turbo not found)*
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e538901188324b17a34f5f5867ee8