### PR TITLE
Fix API services and puppeteer array handling

### DIFF
--- a/express/services/aggregatorSearchLink.js
+++ b/express/services/aggregatorSearchLink.js
@@ -1,4 +1,4 @@
-const puppeteer = require('puppeteer');
+const puppeteer = require('puppeteer-extra');
 const logger = require('../utils/logger');
 
 /**

--- a/express/services/baiduSearch.js
+++ b/express/services/baiduSearch.js
@@ -39,7 +39,9 @@ async function searchImageBaidu(browser, imagePath) {
             } else {
                 // 提取搜尋結果連結（過濾出百度搜尋結果中指向外部的連結）
                 const links = await page.$$eval('a[href]', anchors =>
-                    anchors.map(a => a.href).filter(href => href && !href.includes('baidu.com') && !href.startsWith('javascript'))
+                    Array.from(anchors)
+                    .map(a => a.href)
+                    .filter(href => href && !href.includes('baidu.com') && !href.startsWith('javascript'))
                 );
                 // 去重與去除空值
                 result.links = Array.from(new Set(links));

--- a/express/services/bingSearch.js
+++ b/express/services/bingSearch.js
@@ -44,7 +44,7 @@ async function searchImageBing(browser, imagePath) {
             // 提取搜尋結果連結（Bing 以圖搜尋結果在縮圖點擊後才出現連結，這裡提取縮圖對應的目標頁面連結）
             // 方法：取得所有縮圖父元素的連結
             const links = await page.$$eval('a[href^="https://www.bing.com/images/search?view=detailv2"]', anchors =>
-                anchors.map(a => a.href)
+                Array.from(anchors).map(a => a.href)
             );
             result.links = links;
             

--- a/express/services/rapidApi.service.js
+++ b/express/services/rapidApi.service.js
@@ -26,7 +26,7 @@ async function makeRequest(platform, config) {
         
         const links = items.map(item => {
             if (!item) return null;
-            let url = item.link || item.url || item.play || item.post_url || item.web_link;
+            let url = item.link || item.url || item.play || item.post_url || item.web_link || item.media_url;
             if (!url && platform === 'YouTube' && item.id?.videoId) {
                 return `https://www.youtube.com/watch?v=${item.id.videoId}`;
             }
@@ -55,17 +55,16 @@ const youtubeSearch = (keyword) => makeRequest('YouTube', {
     method: 'GET', url: `https://${YOUTUBE_HOST}/search`, params: { q: keyword, maxResults: '10' }, headers: { 'X-RapidAPI-Key': RAPIDAPI_KEY, 'X-RapidAPI-Host': YOUTUBE_HOST }
 });
 
-// Some RapidAPI providers use '/search' rather than '/search/posts'
 const instagramSearch = (keyword) => makeRequest('Instagram', {
     method: 'GET',
-    url: `https://${INSTAGRAM_HOST}/search`,
+    url: `https://${INSTAGRAM_HOST}/v1/search_posts`,
     params: { query: keyword, count: '10' },
     headers: { 'X-RapidAPI-Key': RAPIDAPI_KEY, 'X-RapidAPI-Host': INSTAGRAM_HOST }
 });
 
 const facebookSearch = (keyword) => makeRequest('Facebook', {
     method: 'GET',
-    url: `https://${FACEBOOK_HOST}/search`,
+    url: `https://${FACEBOOK_HOST}/search/posts`,
     params: { q: keyword, limit: '10' },
     headers: { 'X-RapidAPI-Key': RAPIDAPI_KEY, 'X-RapidAPI-Host': FACEBOOK_HOST }
 });

--- a/express/services/vectorSearch.js
+++ b/express/services/vectorSearch.js
@@ -8,22 +8,30 @@ const PYTHON_VECTOR_URL = process.env.PYTHON_VECTOR_URL || 'http://suzoo_python_
 async function indexImage(localFilePath, id) {
   const form = new FormData();
   form.append('image', fs.createReadStream(localFilePath));
-  form.append('id', id);
+  form.append('id', String(id));
+
+  const url = `${PYTHON_VECTOR_URL}/api/v1/image-insert`;
+  logger.info(`[VectorSearch] Sending index request for ID ${id} to ${url}`);
 
   try {
-    const url = `${PYTHON_VECTOR_URL}/api/v1/image-insert`;
-    logger.info(`[VectorSearch] Sending index request for ID ${id} to ${url}`);
     const resp = await axios.post(url, form, {
-      headers: { ...form.getHeaders() }
+      headers: { 
+        ...form.getHeaders() 
+      },
+      timeout: 10000
     });
-    logger.info(`[VectorSearch] Index request for ID ${id} successful.`);
+    logger.info(`[VectorSearch] Index request for ID ${id} successful. Response:`, resp.data);
     return resp.data;
   } catch (err) {
+    const errorSource = err.response ? 'server' : (err.request ? 'network' : 'request_setup');
     const errorDetail = err.response ? JSON.stringify(err.response.data) : err.message;
-    // Log full error object for better diagnostics
-    logger.error(`[VectorSearch] indexImage failed for ID ${id}.`, err);
-    logger.error(`[VectorSearch] indexImage error detail: ${errorDetail}`);
-    throw new Error(`Vector service failed to index image: ${errorDetail}`);
+    logger.error(`[VectorSearch] indexImage failed for ID ${id}. Source: ${errorSource}.`, {
+        message: err.message,
+        url: url,
+        detail: errorDetail,
+        axiosError: err.toJSON()
+    });
+    throw new Error(`Vector service failed to index image (ID: ${id}): ${errorDetail}`);
   }
 }
 
@@ -32,19 +40,26 @@ async function searchLocalImage(localFilePath, topK = 5) {
   form.append('image', fs.createReadStream(localFilePath));
   form.append('top_k', topK.toString());
 
+  const url = `${PYTHON_VECTOR_URL}/api/v1/image-search`;
+  logger.info(`[VectorSearch] Sending search request to ${url} with topK=${topK}`);
   try {
-    const url = `${PYTHON_VECTOR_URL}/api/v1/image-search`;
-    logger.info(`[VectorSearch] Sending search request to ${url}`);
     const resp = await axios.post(url, form, {
-      headers: { ...form.getHeaders() }
+      headers: { 
+        ...form.getHeaders() 
+      },
+      timeout: 10000
     });
-    logger.info(`[VectorSearch] Search request successful.`);
+    logger.info(`[VectorSearch] Search request successful. Found ${resp.data?.results?.length || 0} results.`);
     return resp.data;
   } catch (err) {
+    const errorSource = err.response ? 'server' : (err.request ? 'network' : 'request_setup');
     const errorDetail = err.response ? JSON.stringify(err.response.data) : err.message;
-    // Log full error object for better diagnostics
-    logger.error('[VectorSearch] searchLocalImage failed:', err);
-    logger.error(`[VectorSearch] searchLocalImage error detail: ${errorDetail}`);
+    logger.error(`[VectorSearch] searchLocalImage failed. Source: ${errorSource}.`, {
+        message: err.message,
+        url: url,
+        detail: errorDetail,
+        axiosError: err.toJSON()
+    });
     throw new Error(`Vector service failed to search image: ${errorDetail}`);
   }
 }

--- a/express/services/vision.service.js
+++ b/express/services/vision.service.js
@@ -8,31 +8,31 @@ let visionClient = null;
 const VISION_MAX_RESULTS = parseInt(process.env.VISION_MAX_RESULTS, 10) || 50;
 
 function initClient() {
-    const keyFilename = path.join('/app/credentials', 'gcp-vision.json');
+    const keyFilename = process.env.GOOGLE_APPLICATION_CREDENTIALS || path.join('/app/credentials', 'gcp-vision.json');
     if (!fs.existsSync(keyFilename)) {
-        const msg = `[Vision Service] FATAL ERROR: Google Vision API credentials file not found at ${keyFilename}.`;
-        logger.error(msg);
+        logger.error(`[Vision Service] FATAL ERROR: Google Vision API credentials file not found at ${keyFilename}. Vision service will be disabled.`);
         return;
     }
 
     try {
         visionClient = new ImageAnnotatorClient({ keyFilename });
-        logger.info('[Service] Google Vision Client initialized.');
+        logger.info('[Service] Google Vision Client initialized successfully.');
     } catch (error) {
-        logger.error('[Vision Service] Failed to initialize Google Vision Client:', error);
+        logger.error('[Vision Service] Failed to initialize Google Vision Client. It will be disabled.', error);
+        visionClient = null;
     }
 }
 
 initClient();
 
 async function searchByBuffer(buffer) {
-    if (!buffer) {
-        return { success: false, links: [], error: 'Image buffer is required.' };
-    }
-
     if (!visionClient) {
-        logger.error('[Vision Service] Client not initialized.');
-        return { success: false, links: [], error: 'Vision client not initialized' };
+        logger.warn('[Vision Service] Client not initialized or failed to initialize. Skipping Google Vision search.');
+        return { success: false, links: [], error: 'Vision client not initialized.' };
+    }
+    if (!buffer || buffer.length === 0) {
+        logger.error('[Vision Service] searchByBuffer called with an invalid buffer.');
+        return { success: false, links: [], error: 'Image buffer is required.' };
     }
 
     try {
@@ -48,28 +48,23 @@ async function searchByBuffer(buffer) {
         logger.info(`[Vision Service] Search by buffer successful, found ${uniqueUrls.length} links.`);
         return { success: true, links: uniqueUrls, error: null };
     } catch (err) {
-        logger.error(`[Vision Service] API call failed: ${err.message}`, { code: err.code });
-        if (err.code === 16) {
-             logger.error('[Vision Service] FATAL: Authentication failed! Verify key file, IAM role, and GOOGLE_APPLICATION_CREDENTIALS path inside the container.');
+        logger.error(`[Vision Service] Google Vision API call failed: ${err.message}`, { code: err.code });
+        if (err.code === 16 || err.code === 7) {
+             logger.error('[Vision Service] FATAL: Authentication/Permission issue! Verify key file, IAM role (Vision AI User), and GOOGLE_APPLICATION_CREDENTIALS path inside the container.');
         }
         return { success: false, links: [], error: err.message };
     }
 }
 
 async function infringementScan(buffer) {
-    if (!buffer) {
+    if (!buffer || buffer.length === 0) {
         throw new Error('Image buffer is required for infringement scan');
     }
 
-    if (!visionClient) {
-        logger.error('[Vision Service] Client not initialized. Cannot perform infringement scan.');
-        return { tineye: null, vision: { success: false, links: [], error: 'Vision client not initialized' } };
-    }
-
-    // Directly send the buffer to TinEye instead of writing a temp file
-    const tineyeResult = await tinEyeService.searchByBuffer(buffer);
-
-    const visionResult = await searchByBuffer(buffer);
+    const [tineyeResult, visionResult] = await Promise.all([
+        tinEyeService.searchByBuffer(buffer),
+        searchByBuffer(buffer)
+    ]);
 
     return { tineye: tineyeResult, vision: visionResult };
 }


### PR DESCRIPTION
## Summary
- improve TinEye API error handling
- adjust RapidAPI endpoints and URL extraction
- make scanner service resilient to missing keywords and invalid buffers
- harden Google Vision client init
- add detailed vector service logging
- fix Puppeteer scripts using Array.from
- switch aggregator search to use puppeteer-extra

## Testing
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5dbd0dc08324a3485cde43d9e80e