### PR TITLE
Refactor protection workflow and PDF services

### DIFF
--- a/express/routes/protect.js
+++ b/express/routes/protect.js
@@ -1,4 +1,4 @@
-// express/routes/protect.js (Final Corrected & Merged Version)
+// express/routes/protect.js (Final Corrected & Robust Version)
 const express = require('express');
 const multer = require('multer');
 const fs = require('fs');
@@ -7,41 +7,32 @@ const sharp = require('sharp');
 const { Op } = require('sequelize');
 const logger = require('../utils/logger');
 
-// --- 資料庫模型 ---
 const { User, File } = require('../models');
 
-// --- 服務與工具 ---
 const chain = require('../utils/chain');
 const ipfsService = require('../services/ipfsService');
 const scannerService = require('../services/scanner.service');
 const fingerprintService = require('../services/fingerprintService');
-const { indexImageVector, searchImageByVector } = require('../utils/vectorSearch');
-const { generateScanPDFWithMatches } = require('../services/pdfService');
-const { generateCertificatePDF } = require('../services/pdf.service.js');
+const vectorSearchService = require('../services/vectorSearch');
+const { generateCertificatePDF, generateScanPDFWithMatches } = require('../services/pdf.service.js');
 
 const router = express.Router();
 
-// --- 目錄設定 ---
 const UPLOAD_BASE_DIR = path.resolve(__dirname, '../../uploads');
 const REPORTS_DIR = path.join(UPLOAD_BASE_DIR, 'reports');
 const TEMP_DIR = path.join(UPLOAD_BASE_DIR, 'temp');
 
-// --- 啟動時檢查並建立目錄 ---
 [REPORTS_DIR, TEMP_DIR].forEach(dir => {
     if (!fs.existsSync(dir)) {
         fs.mkdirSync(dir, { recursive: true });
     }
 });
 
-// --- Multer 檔案上傳設定 ---
 const upload = multer({
     dest: TEMP_DIR,
-    limits: { fileSize: 100 * 1024 * 1024 } // 限制 100 MB
+    limits: { fileSize: 100 * 1024 * 1024 }
 });
 
-/**
- * 路由: 步驟一 - 保護檔案 (POST /step1)
- */
 router.post('/step1', upload.single('file'), async (req, res) => {
     if (!req.file) {
         return res.status(400).json({ error: '未提供檔案。' });
@@ -50,11 +41,9 @@ router.post('/step1', upload.single('file'), async (req, res) => {
     const { realName, birthDate, phone, address, email, title, keywords } = req.body;
     const { path: tempPath, originalname, mimetype } = req.file;
     const userIdFromToken = req.user ? req.user.id : null;
-    let fileBuffer; // 將 Buffer 提升到外部作用域
 
     try {
-        // 【修正】立即讀取檔案到 Buffer，並在後續流程中重複使用此 Buffer
-        fileBuffer = fs.readFileSync(tempPath);
+        const fileBuffer = fs.readFileSync(tempPath);
 
         let user;
         if (userIdFromToken) {
@@ -65,7 +54,7 @@ router.post('/step1', upload.single('file'), async (req, res) => {
             if (phone) whereConditions.push({ phone });
             user = await User.findOne({ where: { [Op.or]: whereConditions } });
         }
-        
+
         if (!user) {
             if (!realName || !email) {
                 return res.status(400).json({ error: '對於新用戶，姓名和電子郵件為必填項。'});
@@ -74,7 +63,7 @@ router.post('/step1', upload.single('file'), async (req, res) => {
             logger.info(`[Step 1] New user created: ${user.email} (ID: ${user.id})`);
         }
 
-        const fingerprint = await fingerprintService.getHash(tempPath);
+        const fingerprint = await fingerprintService.getHash(fileBuffer);
         const existingFile = await File.findOne({ where: { fingerprint } });
         if (existingFile) {
             logger.warn(`[Step 1] Conflict: File with fingerprint ${fingerprint} already exists.`);
@@ -106,15 +95,20 @@ router.post('/step1', upload.single('file'), async (req, res) => {
         });
         logger.info(`[Step 1] File record saved to database, File ID: ${newFile.id}`);
 
-        // 【修正】將 fileBuffer 傳遞給背景任務，而不是 tempPath
-        process.nextTick(() => {
-            indexImageVector(fileBuffer, newFile.id.toString())
-                .then(() => logger.info(`[Background] Vector indexing complete for File ID: ${newFile.id}`))
-                .catch(err => logger.error(`[Background] Vector indexing failed for File ID: ${newFile.id}`, err));
+        setImmediate(async () => {
+            try {
+                await vectorSearchService.indexImage(tempPath, newFile.id.toString());
+                logger.info(`[Background] Vector indexing complete for File ID: ${newFile.id}`);
+            } catch (err) {
+                logger.error(`[Background] Vector indexing failed for File ID: ${newFile.id}`, err);
+            }
 
-            generateCertificatePDF({ fileId: newFile.id })
-                .then(pdfPath => logger.info(`[Background] Certificate PDF generated for File ID: ${newFile.id} at ${pdfPath}`))
-                .catch(err => logger.error(`[Background] Certificate PDF generation failed for File ID: ${newFile.id}`, err));
+            try {
+                const pdfPath = await generateCertificatePDF({ fileId: newFile.id, user, file: newFile });
+                logger.info(`[Background] Certificate PDF generated for File ID: ${newFile.id} at ${pdfPath}`);
+            } catch (err) {
+                logger.error(`[Background] Certificate PDF generation failed for File ID: ${newFile.id}`, err);
+            }
         });
 
         res.status(201).json({ message: '檔案保護成功！', file: newFile });
@@ -126,43 +120,50 @@ router.post('/step1', upload.single('file'), async (req, res) => {
         });
         res.status(500).json({ message: '伺服器內部錯誤', error: error.message });
     } finally {
-        fs.unlink(tempPath, (err) => {
+        fs.unlink(tempPath, err => {
             if (err) logger.warn(`[Step 1] Failed to delete temp file ${tempPath}:`, err);
         });
     }
 });
 
-/**
- * 路由: Step2 - 觸發掃描 (POST /step2)
- */
-router.post('/step2', async (req, res) => {
-    const { fileId } = req.body || {};
+const handleScanRequest = async (req, res) => {
+    const fileId = req.params.fileId || req.body.fileId;
+    const routeName = req.path.includes('step2') ? '[Step2]' : '[Scan Route]';
+
     if (!fileId) {
         return res.status(400).json({ error: 'fileId is required' });
     }
+    logger.info(`${routeName} Received scan request for File ID: ${fileId}`);
 
     try {
         const file = await File.findByPk(fileId);
         if (!file) {
             return res.status(404).json({ error: '找不到指定的檔案紀錄。' });
         }
+        logger.info(`${routeName} File record found. Filename: ${file.filename}`);
 
         const imageBuffer = await ipfsService.getFile(file.ipfs_hash);
         if (!imageBuffer) {
             return res.status(500).json({ error: '從 IPFS 讀取圖片失敗。' });
         }
+        logger.info(`${routeName} Image retrieved from IPFS successfully.`);
 
+        logger.info(`${routeName} Performing full scan...`);
         const scanResults = await scannerService.performFullScan({
             buffer: imageBuffer,
             keyword: file.keywords || file.title || file.filename
         });
+        logger.info(`${routeName} Full scan complete.`);
 
-        const vectorMatches = await searchImageByVector(imageBuffer);
+        logger.info(`${routeName} Performing internal vector search...`);
+        const vectorMatches = await vectorSearchService.searchLocalImage(imageBuffer);
+        logger.info(`${routeName} Internal vector search found ${vectorMatches?.results?.length || 0} similar results.`);
+
         const finalResults = { ...scanResults, internalMatches: vectorMatches };
-
         file.status = 'scanned';
         file.resultJson = JSON.stringify(finalResults);
         await file.save();
+        logger.info(`${routeName} Scan results saved to database.`);
 
         const reportFileName = `report_${fileId}_${Date.now()}.pdf`;
         const reportPath = path.join(REPORTS_DIR, reportFileName);
@@ -170,91 +171,21 @@ router.post('/step2', async (req, res) => {
 
         const suspiciousLinks = [
             ...(finalResults.imageSearch?.googleVision?.links || []),
-            ...((finalResults.imageSearch?.tineye?.matches || []).map(m => m.url))
-        ];
+            ...((finalResults.imageSearch?.tineye?.matches || []).flatMap(m => m.backlinks || [m.url]))
+        ].filter(Boolean);
 
-        process.nextTick(() => {
-            generateScanPDFWithMatches({
-                file: {
-                    id: file.id,
-                    filename: file.filename,
-                    fingerprint: file.fingerprint,
-                    status: file.status,
-                },
-                suspiciousLinks,
-                matchedImages: vectorMatches,
-            }, reportPath)
-               .then(() => file.update({ report_url: reportUrl }))
-               .catch(err => logger.error(`[Step2] Failed to generate or save report for File ID: ${fileId}`, err));
-        });
-
-        res.status(200).json({ message: 'Step2 處理完成', fileId, reportUrl, results: finalResults });
-    } catch (error) {
-        logger.error(`[Step2] A critical error occurred while scanning file ID ${fileId}:`, error);
-        res.status(500).json({ message: '掃描時發生內部伺服器錯誤', error: error.message });
-    }
-});
-
-/**
- * 路由: 掃描指定檔案 (GET /scan/:fileId)
- */
-router.get('/scan/:fileId', async (req, res) => {
-    const { fileId } = req.params;
-    logger.info(`[Scan Route] Received scan request for File ID: ${fileId}`);
-
-    try {
-        const file = await File.findByPk(fileId);
-        if (!file) {
-            return res.status(404).json({ error: '找不到指定的檔案紀錄。' });
-        }
-        logger.info(`[Scan Route] File record found. Filename: ${file.filename}`);
-
-        const imageBuffer = await ipfsService.getFile(file.ipfs_hash);
-        if (!imageBuffer) {
-            return res.status(500).json({ error: '從 IPFS 讀取圖片失敗。' });
-        }
-        logger.info(`[Scan Route] Image retrieved from IPFS successfully.`);
-
-        logger.info(`[Scan Route] Performing full scan...`);
-        const scanResults = await scannerService.performFullScan({
-            buffer: imageBuffer,
-            keyword: file.keywords || file.title || file.filename
-        });
-        logger.info(`[Scan Route] Full scan complete.`);
-
-        logger.info(`[Scan Route] Performing internal vector search...`);
-        const vectorMatches = await searchImageByVector(imageBuffer);
-        logger.info(`[Scan Route] Internal vector search found ${vectorMatches.length} similar results.`);
-
-        const finalResults = { ...scanResults, internalMatches: vectorMatches };
-        file.status = 'scanned';
-        file.resultJson = JSON.stringify(finalResults);
-        await file.save();
-        logger.info(`[Scan Route] Scan results saved to database.`);
-
-        const reportFileName = `report_${fileId}_${Date.now()}.pdf`;
-        const reportPath = path.join(REPORTS_DIR, reportFileName);
-        const reportUrl = `${process.env.PUBLIC_HOST}/uploads/reports/${reportFileName}`;
-
-        const suspiciousLinks = [
-            ...(finalResults.imageSearch?.googleVision?.links || []),
-            ...((finalResults.imageSearch?.tineye?.matches || []).map(m => m.url))
-        ];
-
-        process.nextTick(() => {
-            generateScanPDFWithMatches({
-                file: {
-                    id: file.id,
-                    filename: file.filename,
-                    fingerprint: file.fingerprint,
-                    status: file.status,
-                },
-                suspiciousLinks,
-                matchedImages: vectorMatches,
-            }, reportPath)
-               .then(() => file.update({ report_url: reportUrl }))
-               .then(() => logger.info(`[Scan Route] Report generated and URL updated for File ID: ${fileId}`))
-               .catch(err => logger.error(`[Scan Route] Failed to generate or save report for File ID: ${fileId}`, err));
+        setImmediate(async () => {
+            try {
+                await generateScanPDFWithMatches({
+                    file: file,
+                    suspiciousLinks,
+                    matchedImages: vectorMatches?.results || [],
+                }, reportPath);
+                await file.update({ report_url: reportUrl });
+                logger.info(`${routeName} Report generated and URL updated for File ID: ${fileId}`);
+            } catch (err) {
+                logger.error(`${routeName} Failed to generate or save report for File ID: ${fileId}`, err);
+            }
         });
 
         res.status(200).json({
@@ -262,17 +193,17 @@ router.get('/scan/:fileId', async (req, res) => {
             reportUrl: reportUrl,
             results: finalResults
         });
-        logger.info(`[Scan Route] Successfully sent scan results to client.`);
+        logger.info(`${routeName} Successfully sent scan results to client.`);
 
     } catch (error) {
-        logger.error(`[Scan Route] A critical error occurred while scanning file ID ${fileId}:`, error);
+        logger.error(`${routeName} A critical error occurred while scanning file ID ${fileId}:`, error);
         res.status(500).json({ message: '掃描時發生內部伺服器錯誤', error: error.message });
     }
-});
+};
 
-/**
- * 路由: 動態浮水印預覽 (GET /view/:fileId)
- */
+router.post('/step2', handleScanRequest);
+router.get('/scan/:fileId', handleScanRequest);
+
 router.get('/view/:fileId', async (req, res) => {
     const { fileId } = req.params;
     const userEmail = req.user ? req.user.email : 'anonymous';
@@ -284,24 +215,24 @@ router.get('/view/:fileId', async (req, res) => {
 
         const originalImageBuffer = await ipfsService.getFile(file.ipfs_hash);
         if (!originalImageBuffer) return res.status(500).send('Could not retrieve image from IPFS');
-        
+
         const watermarkLines = [
             `Protected by SooZoo Kaizoku Hunter`,
             `Accessor: ${userEmail} @ ${userIp}`,
             `Time: ${new Date().toISOString()}`
         ];
-        
-        const svgTextElements = watermarkLines.map((line, index) => 
+
+        const svgTextElements = watermarkLines.map((line, index) =>
             `<tspan x="50%" dy="${index === 0 ? 0 : '1.2em'}">${line}</tspan>`
         ).join('');
 
         const watermarkSvg = `
             <svg width="600" height="150">
                 <style>
-                    .title { 
-                        fill: rgba(255, 255, 255, 0.4); 
-                        font-size: 20px; 
-                        font-family: Arial, sans-serif; 
+                    .title {
+                        fill: rgba(255, 255, 255, 0.4);
+                        font-size: 20px;
+                        font-family: Arial, sans-serif;
                         font-weight: bold;
                         text-anchor: middle;
                     }

--- a/express/services/pdf.service.js
+++ b/express/services/pdf.service.js
@@ -1,16 +1,123 @@
+const PDFDocument = require('pdfkit');
+const fs = require('fs');
+const path = require('path');
 const logger = require('../utils/logger');
+const { User, File } = require('../models');
 
-/**
- * Temporary placeholder for certificate PDF generation.
- * This implementation only logs and returns a fake path.
- * Replace with real PDF generation logic when ready.
- * @param {object} data
- * @returns {Promise<string>} absolute file path of generated PDF
- */
-async function generateCertificatePDF(data) {
-  logger.warn('[PDF Service] Using temporary generateCertificatePDF implementation');
-  await new Promise(res => setTimeout(res, 50));
-  return '/tmp/fake-certificate.pdf';
+const UPLOAD_BASE_DIR = path.resolve(__dirname, '../../uploads');
+const CERT_DIR = path.join(UPLOAD_BASE_DIR, 'certificates');
+
+if (!fs.existsSync(CERT_DIR)) {
+    fs.mkdirSync(CERT_DIR, { recursive: true });
 }
 
-module.exports = { generateCertificatePDF };
+async function generateCertificatePDF(data) {
+    const { fileId } = data;
+    logger.info(`[PDF Service] Starting certificate generation for File ID: ${fileId}`);
+    try {
+        const file = data.file || await File.findByPk(fileId);
+        const user = data.user || await User.findByPk(file.user_id);
+        if (!file || !user) throw new Error(`File or User not found for File ID: ${fileId}`);
+
+        const doc = new PDFDocument({ size: 'A4', margin: 50 });
+        const fileName = `certificate_${fileId}.pdf`;
+        const filePath = path.join(CERT_DIR, fileName);
+        const writeStream = fs.createWriteStream(filePath);
+        doc.pipe(writeStream);
+
+        doc.fontSize(25).text('原創著作權證明書 (Certificate of Copyright)', { align: 'center' });
+        doc.moveDown(2);
+
+        doc.fontSize(14);
+        doc.text(`茲證明以下數位作品，其相關權利歸屬下列著作權人所有：`);
+        doc.moveDown();
+
+        doc.font('Helvetica-Bold').text('著作權人資訊 (Copyright Holder Information):');
+        doc.font('Helvetica').text(`姓名 (Name): ${user.name}`);
+        doc.text(`電子郵件 (Email): ${user.email}`);
+        doc.text(`電話 (Phone): ${user.phone || 'N/A'}`);
+        doc.moveDown();
+
+        doc.font('Helvetica-Bold').text('作品資訊 (Work Information):');
+        doc.font('Helvetica').text(`作品標題 (Title): ${file.title || 'Untitled'}`);
+        doc.text(`原始檔名 (Original Filename): ${file.filename}`);
+        doc.text(`存證時間 (Timestamp): ${file.createdAt.toISOString()}`);
+        doc.moveDown();
+
+        doc.font('Helvetica-Bold').text('數位存證指紋 (Digital Fingerprints):');
+        doc.font('Helvetica').text(`SHA256: ${file.fingerprint}`, { oblique: true });
+        doc.text(`IPFS CID: ${file.ipfs_hash}`, { oblique: true });
+        doc.text(`區塊鏈交易雜湊 (TxHash): ${file.tx_hash}`, { oblique: true });
+        doc.moveDown(3);
+
+        doc.fontSize(10).text('此證明由 SooZoo Kaizoku Hunter 系統基於區塊鏈與 IPFS 技術自動生成，用以記錄作品於特定時間點的存在性與歸屬。', { align: 'center' });
+
+        await doc.end();
+        await new Promise((resolve, reject) => {
+            writeStream.on('finish', resolve);
+            writeStream.on('error', reject);
+        });
+        logger.info(`[PDF Service] Certificate successfully generated at: ${filePath}`);
+        await file.update({ certificate_url: `/uploads/certificates/${fileName}` });
+        return filePath;
+    } catch (error) {
+        logger.error(`[PDF Service] Failed to generate certificate for File ID: ${fileId}`, error);
+        throw error;
+    }
+}
+
+async function generateScanPDFWithMatches(data, reportPath) {
+    logger.info(`[PDF Service] Generating scan report for File ID: ${data.file.id}`);
+    const { file, suspiciousLinks, matchedImages } = data;
+    try {
+        const doc = new PDFDocument({ size: 'A4', margin: 50 });
+        const writeStream = fs.createWriteStream(reportPath);
+        doc.pipe(writeStream);
+
+        doc.fontSize(20).text(`侵權掃描報告 (Infringement Scan Report)`, { align: 'center' });
+        doc.fontSize(12).text(`報告生成時間: ${new Date().toISOString()}`, { align: 'center' });
+        doc.moveDown(2);
+
+        doc.fontSize(14).font('Helvetica-Bold').text('原始檔案資訊:');
+        doc.font('Helvetica').text(`檔案ID: ${file.id}`);
+        doc.text(`檔名: ${file.filename}`);
+        doc.text(`SHA256 指紋: ${file.fingerprint}`);
+        doc.moveDown();
+
+        doc.fontSize(14).font('Helvetica-Bold').text('網路可疑連結 (Suspicious Links):');
+        if (suspiciousLinks && suspiciousLinks.length > 0) {
+            suspiciousLinks.slice(0, 30).forEach(link => {
+                doc.fillColor('blue').text(link, { link: link, underline: true });
+                doc.moveDown(0.5);
+            });
+        } else {
+            doc.fillColor('black').text('未發現可疑的外部連結。');
+        }
+        doc.moveDown();
+
+        doc.addPage().fontSize(14).font('Helvetica-Bold').text('內部比對相似圖片 (Internal Similar Images):');
+        if (matchedImages && matchedImages.length > 0) {
+            matchedImages.forEach(match => {
+                doc.fillColor('black').text(`- 檔案ID: ${match.id}, 相似度: ${(match.distance * 100).toFixed(2)}%`);
+                doc.moveDown(0.5);
+            });
+        } else {
+            doc.fillColor('black').text('未在內部資料庫中發現相似圖片。');
+        }
+
+        await doc.end();
+        await new Promise((resolve, reject) => {
+            writeStream.on('finish', resolve);
+            writeStream.on('error', reject);
+        });
+        logger.info(`[PDF Service] Scan report successfully generated for File ID: ${file.id}`);
+    } catch (error) {
+        logger.error(`[PDF Service] Failed to generate scan report for File ID: ${file.id}`, error);
+        throw error;
+    }
+}
+
+module.exports = {
+    generateCertificatePDF,
+    generateScanPDFWithMatches,
+};

--- a/express/services/rapidApi.service.js
+++ b/express/services/rapidApi.service.js
@@ -1,58 +1,84 @@
-// express/services/rapidApi.service.js (Final Refactored Version)
+// express/services/rapidApi.service.js (Final Configurable Version)
 const axios = require('axios');
 const logger = require('../utils/logger');
 
 const {
     RAPIDAPI_KEY,
-    RAPIDAPI_TIKTOK_URL,
     RAPIDAPI_YOUTUBE_URL,
+    RAPIDAPI_TIKTOK_URL,
     RAPIDAPI_INSTAGRAM_URL,
     RAPIDAPI_FACEBOOK_URL
 } = process.env;
 
-function getHostFromUrl(url) {
+const getHostFromUrl = (url) => {
     try {
+        if (!url) return null;
         return new URL(url).hostname;
-    } catch {
+    } catch (e) {
+        logger.error(`[RapidAPI] Invalid URL in .env file: ${url}`);
         return null;
     }
-}
+};
 
-async function makeRequest(platform, url, params, keyword) {
-    const host = getHostFromUrl(url);
-    if (!RAPIDAPI_KEY || !url || !host) {
-        const errorMsg = `[RapidAPI][${platform}] API Key or URL/Host not configured.`;
+const API_CONFIGS = {
+    YouTube: {
+        url: RAPIDAPI_YOUTUBE_URL,
+        host: getHostFromUrl(RAPIDAPI_YOUTUBE_URL),
+        params: (keyword) => ({ q: keyword, hl: 'en', gl: 'US' })
+    },
+    TikTok: {
+        url: RAPIDAPI_TIKTOK_URL,
+        host: getHostFromUrl(RAPIDAPI_TIKTOK_URL),
+        params: (keyword) => ({ keywords: keyword, count: 10 })
+    },
+    Instagram: {
+        url: RAPIDAPI_INSTAGRAM_URL,
+        host: getHostFromUrl(RAPIDAPI_INSTAGRAM_URL),
+        params: (keyword) => ({ query: keyword })
+    },
+    Facebook: {
+        url: RAPIDAPI_FACEBOOK_URL,
+        host: getHostFromUrl(RAPIDAPI_FACEBOOK_URL),
+        params: (keyword) => ({ query: keyword })
+    }
+};
+
+async function makeRequest(platform, keyword) {
+    const config = API_CONFIGS[platform];
+    if (!RAPIDAPI_KEY || !config.url || !config.host) {
+        const errorMsg = `[RapidAPI][${platform}] API Key, URL, or Host is not configured in .env file. Please check your .env configuration.`;
         logger.warn(errorMsg);
         return { success: false, links: [], error: errorMsg };
     }
 
-    logger.info(`[RapidAPI][${platform}] Searching with keyword: "${keyword}" at ${url}`);
+    logger.info(`[RapidAPI][${platform}] Searching with keyword: "${keyword}" at endpoint: ${config.url}`);
 
     try {
         const response = await axios.request({
             method: 'GET',
-            url,
-            params,
-            headers: {
-                'X-RapidAPI-Key': RAPIDAPI_KEY,
-                'X-RapidAPI-Host': host
-            },
+            url: config.url,
+            params: config.params(keyword),
+            headers: { 'X-RapidAPI-Key': RAPIDAPI_KEY, 'X-RapidAPI-Host': config.host },
             timeout: 15000
         });
 
-        const items = response.data?.data?.items || response.data?.results?.items || response.data?.videos || response.data?.posts || response.data?.data || response.data?.results || response.data || [];
+        const items = response.data?.data?.items || response.data?.results?.items || response.data?.videos || response.data?.posts || response.data?.data || response.data?.results || response.data?.items || response.data || [];
+
         if (!Array.isArray(items)) {
-            logger.warn(`[RapidAPI][${platform}] Response data is not an array.`, response.data);
-            return { success: true, links: [], error: null };
+            logger.warn(`[RapidAPI][${platform}] Response data is not an array. Full response data:`, response.data);
+            return { success: true, links: [], error: 'Response data is not an array' };
         }
 
         const links = items.map(item => {
             if (!item) return null;
-            let url = item.link || item.url || item.play || item.post_url || item.web_link || item.media_url;
-            if (!url && platform === 'YouTube' && item.id?.videoId) {
-                return `https://www.youtube.com/watch?v=${item.id.videoId}`;
+            let itemUrl = item.link || item.url || item.play || item.post_url || item.web_link || item.media_url;
+            if (!itemUrl && platform === 'YouTube' && item.video?.videoId) {
+                return `https://www.youtube.com/watch?v=${item.video.videoId}`;
             }
-            return (url && typeof url === 'string' && url.startsWith('http')) ? url : null;
+            if (itemUrl && typeof itemUrl === 'string' && itemUrl.startsWith('http')) {
+                return itemUrl;
+            }
+            return null;
         }).filter(Boolean);
 
         logger.info(`[RapidAPI][${platform}] Search successful, found ${links.length} links.`);
@@ -65,9 +91,9 @@ async function makeRequest(platform, url, params, keyword) {
     }
 }
 
-const tiktokSearch = (keyword) => makeRequest('TikTok', RAPIDAPI_TIKTOK_URL, { keywords: keyword, count: '10' }, keyword);
-const youtubeSearch = (keyword) => makeRequest('YouTube', RAPIDAPI_YOUTUBE_URL, { q: keyword, maxResults: '10' }, keyword);
-const instagramSearch = (keyword) => makeRequest('Instagram', RAPIDAPI_INSTAGRAM_URL, { query: keyword, count: '10' }, keyword);
-const facebookSearch = (keyword) => makeRequest('Facebook', RAPIDAPI_FACEBOOK_URL, { q: keyword, limit: '10' }, keyword);
-
-module.exports = { tiktokSearch, youtubeSearch, instagramSearch, facebookSearch };
+module.exports = {
+    tiktokSearch: (keyword) => makeRequest('TikTok', keyword),
+    youtubeSearch: (keyword) => makeRequest('YouTube', keyword),
+    instagramSearch: (keyword) => makeRequest('Instagram', keyword),
+    facebookSearch: (keyword) => makeRequest('Facebook', keyword)
+};


### PR DESCRIPTION
## Summary
- refactor `protect` routes to unify scanning logic
- create robust PDF service for certificates and reports
- revise RapidAPI service for configurable endpoints
- update vector search service to support buffer input

## Testing
- `npm test` *(fails: vision tests)*

------
https://chatgpt.com/codex/tasks/task_e_685f74b9c6a483249d1b8109e7285ec0