### PR TITLE
Fix vector search indexing and TinEye integration

### DIFF
--- a/express/package.json
+++ b/express/package.json
@@ -36,7 +36,8 @@
     "sequelize": "^6.31.1",
     "sharp": "^0.32.1",
     "web3": "^1.10.0",
-    "winston": "^3.13.0"
+    "winston": "^3.13.0",
+    "file-type": "^19.0.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/express/services/vectorSearch.js
+++ b/express/services/vectorSearch.js
@@ -7,10 +7,14 @@ const PYTHON_VECTOR_URL = process.env.PYTHON_VECTOR_URL || 'http://suzoo_python_
 
 async function indexImage(imageInput, id) {
   const form = new FormData();
+
+  // **FIX**: 處理傳入的 buffer 或 file path
   if (Buffer.isBuffer(imageInput)) {
-    form.append('image', imageInput, { filename: `image-${id}.jpg` });
-  } else {
+    form.append('image', imageInput, { filename: `image-${id}.jpg` }); // filename is arbitrary
+  } else if (typeof imageInput === 'string') { // Fallback for file path
     form.append('image', fs.createReadStream(imageInput));
+  } else {
+    throw new Error('Invalid imageInput type for indexImage. Must be a buffer or file path.');
   }
   form.append('id', String(id));
 
@@ -43,8 +47,10 @@ async function searchLocalImage(imageInput, topK = 5) {
   const form = new FormData();
   if (Buffer.isBuffer(imageInput)) {
     form.append('image', imageInput, { filename: 'search.jpg' });
-  } else {
+  } else if (typeof imageInput === 'string') {
     form.append('image', fs.createReadStream(imageInput));
+  } else {
+    throw new Error('Invalid imageInput type for searchLocalImage. Must be a buffer or file path.');
   }
   form.append('top_k', topK.toString());
 


### PR DESCRIPTION
## Summary
- add `file-type` dependency for mime detection
- fix Step1 flow in `protect.js` for race condition and vector indexing
- improve scanning report assembly
- support buffer inputs in vectorSearch service
- detect actual image MIME type for TinEye requests

## Testing
- `pnpm test` *(fails: suzoo-express tests require credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68602889d80083248fa2fb427c044d0e