### PR TITLE
Fix express startup healthcheck timing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       interval: 15s
       timeout: 5s
       retries: 5
-      start_period: 20s
+      start_period: 60s
     restart: always
     logging: *default-logging
 

--- a/express/models/index.js
+++ b/express/models/index.js
@@ -37,7 +37,7 @@ Object.keys(db).forEach(modelName => {
 logger.info('[Database] Model associations configured.');
 
 // --- 4. 新增關鍵的資料庫連接函式 ---
-const connectToDatabase = async (retries = 5, delay = 5000) => {
+const connectToDatabase = async (retries = 10, delay = 5000) => {
   for (let i = 1; i <= retries; i++) {
     try {
       await sequelize.authenticate();


### PR DESCRIPTION
## Summary
- extend the startup wait time for `suzoo_express` healthcheck
- allow extra retries when connecting to PostgreSQL

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68602c5cc74c8324bd244f387f3fb0d3