### PR TITLE
Fix web3 protobuf conflict

### DIFF
--- a/fastapi/main.py
+++ b/fastapi/main.py
@@ -76,15 +76,15 @@ cloudinary.config(
 # === Web3 (Ganache)
 w3 = Web3(Web3.HTTPProvider(BLOCKCHAIN_RPC_URL))
 
-# 改用 w3.isConnected() 以相容舊版 Web3
-if w3.isConnected():
+# 改用 w3.is_connected() 以相容新版 Web3
+if w3.is_connected():
     print("[FastAPI] Ganache connected at", BLOCKCHAIN_RPC_URL)
 else:
     print("[FastAPI] Ganache not connected:", BLOCKCHAIN_RPC_URL)
 
 # 預設合約 ABI
 contract = None
-if CONTRACT_ADDR and GANACHE_PRIV_KEY and w3.isConnected():
+if CONTRACT_ADDR and GANACHE_PRIV_KEY and w3.is_connected():
     try:
         abi = [
             {
@@ -117,14 +117,14 @@ def storeRecordOnChain(fingerprint, ipfsHash):
         return None
     try:
         acct = w3.eth.account.from_key(GANACHE_PRIV_KEY)
-        nonce = w3.eth.getTransactionCount(acct.address)
+        nonce = w3.eth.get_transaction_count(acct.address)
         tx_data = contract.functions.storeRecord(
             fingerprint, ipfsHash
-        ).buildTransaction({
+        ).build_transaction({
             'from': acct.address,
             'nonce': nonce,
             'gas': 300000,
-            'gasPrice': w3.toWei('1', 'gwei')
+            'gasPrice': w3.to_wei('1', 'gwei')
         })
         signed_tx = w3.eth.account.sign_transaction(tx_data, private_key=GANACHE_PRIV_KEY)
         tx_hash = w3.eth.send_raw_transaction(signed_tx.rawTransaction)

--- a/fastapi/requirements.txt
+++ b/fastapi/requirements.txt
@@ -4,7 +4,8 @@ requests==2.28.2
 python-dotenv==1.0.0
 psycopg2-binary==2.9.6
 cloudinary==1.30.0
-web3==5.31.3
+# Upgraded to v6 to avoid protobuf conflict with pymilvus
+web3>=6.0.0
 fpdf==1.7.2
 pydantic==1.10.7
 ipfshttpclient==0.8.0a2


### PR DESCRIPTION
## Summary
- upgrade `web3` to v6 to resolve protobuf dependency issues
- update FastAPI blockchain code to new web3 v6 API

## Testing
- `docker compose build suzoo_fastapi` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68611945ac348324814839f19982e94c