### PR TITLE
Increase AI timeout and remove stale temp files

### DIFF
--- a/express/routes/protect.js
+++ b/express/routes/protect.js
@@ -70,7 +70,10 @@ router.post('/step1', upload.single('file'), async (req, res) => {
         const existingFile = await File.findOne({ where: { fingerprint } });
         if (existingFile) {
             logger.warn(`[Step 1] Conflict: File with fingerprint ${fingerprint} already exists.`);
-            fs.unlinkSync(tempPath);
+            // **FIX**: Ensure temp file is unlinked even on conflict exit
+            fs.unlink(tempPath, (err) => {
+                if (err) logger.warn(`[Step 1] Conflict-Cleanup: Failed to delete temp file ${tempPath}:`, err);
+            });
             return res.status(409).json({
                 message: '此圖片先前已被保護。',
                 error: 'Conflict',

--- a/express/services/vectorSearch.js
+++ b/express/services/vectorSearch.js
@@ -1,11 +1,12 @@
-// express/services/vectorSearch.js (Corrected Environment Variable)
+// express/services/vectorSearch.js (Increased Timeout)
 const axios = require('axios');
 const fs = require('fs');
 const FormData = require('form-data');
 const logger = require('../utils/logger');
 
-// **FIX**: Use the correct environment variable 'VECTOR_SERVICE_URL'
 const VECTOR_URL = process.env.VECTOR_SERVICE_URL || 'http://suzoo_fastapi:8000';
+// ** FIX: Increased timeout from 10 seconds to 60 seconds for AI model processing
+const AXIOS_TIMEOUT = 60000;
 
 async function indexImage(imageInput, id) {
   const form = new FormData();
@@ -27,7 +28,7 @@ async function indexImage(imageInput, id) {
       headers: {
         ...form.getHeaders()
       },
-      timeout: 10000
+      timeout: AXIOS_TIMEOUT // Use the new timeout value
     });
     logger.info(`[VectorSearch] Index request for ID ${id} successful. Response:`, resp.data);
     return resp.data;
@@ -62,7 +63,7 @@ async function searchLocalImage(imageInput, topK = 5) {
       headers: {
         ...form.getHeaders()
       },
-      timeout: 10000
+      timeout: AXIOS_TIMEOUT // Use the new timeout value
     });
     logger.info(`[VectorSearch] Search request successful. Found ${resp.data?.results?.length || 0} results.`);
     return resp.data;


### PR DESCRIPTION
## Summary
- extend axios timeout in vectorSearch.js to 60s
- delete temp files when duplicate image upload is detected

## Testing
- `pnpm test` *(fails: sharp module missing and vision credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68611f85b41083249c15d21f54214ada