### PR TITLE
Fix Milvus service command in compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,6 +127,7 @@ services:
   milvus:
     container_name: suzoo_milvus
     image: milvusdb/milvus:${MILVUS_IMAGE_TAG:-v2.3.16}
+    command: ["milvus", "run", "standalone"]
     ports:
       - "19530:19530"
       - "9091:9091"


### PR DESCRIPTION
## Summary
- restore missing `command` for Milvus to run standalone

## Testing
- `pnpm test` *(fails: sharp module not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68616589bfd88324b6d5643a615259ae