### PR TITLE
Fix RabbitMQ auth and startup order

### DIFF
--- a/.env
+++ b/.env
@@ -61,7 +61,11 @@ MILVUS_IMAGE_TAG=v2.3.16
 ########################################
 # RabbitMQ / Celery
 ########################################
-BROKER_URL=amqp://admin:123456@suzoo_rabbitmq:5672//
+# **FIX**: 新增 RabbitMQ 的使用者和密碼變數
+RABBITMQ_DEFAULT_USER=suzoo_user
+RABBITMQ_DEFAULT_PASS=KaiShieldRabbitPass2024!
+# **FIX**: 使用變數來建立 BROKER_URL
+BROKER_URL=amqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@suzoo_rabbitmq:5672
 RESULT_BACKEND=rpc://
 
 ########################################

--- a/.env.example
+++ b/.env.example
@@ -117,7 +117,11 @@ MILVUS_IMAGE_TAG=v2.4.4-20240531-8e7f36d9-amd64
 ########################################
 # RabbitMQ / Celery (可調整)
 ########################################
-BROKER_URL=amqp://admin:123456@suzoo_rabbitmq:5672//
+# **FIX**: 新增 RabbitMQ 的使用者和密碼變數
+RABBITMQ_DEFAULT_USER=suzoo_user
+RABBITMQ_DEFAULT_PASS=KaiShieldRabbitPass2024!
+# **FIX**: 使用變數來建立 BROKER_URL
+BROKER_URL=amqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@suzoo_rabbitmq:5672
 RESULT_BACKEND=rpc://
 
 ########################################

--- a/express/models/ScanTask.js
+++ b/express/models/ScanTask.js
@@ -9,7 +9,8 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.INTEGER,
       allowNull: false,
       references: {
-        model: 'files',
+        // **FIX**: 確保參考的資料表名稱是 'Files' (首字母大寫的複數形式)
+        model: 'Files',
         key: 'id',
       },
     },

--- a/express/services/queue.service.js
+++ b/express/services/queue.service.js
@@ -8,18 +8,19 @@ class QueueService {
     constructor() {
         this.connection = null;
         this.channel = null;
-        this.connect();
     }
 
-    async connect() {
+    // **FIX**: Changed to an async init method
+    async init() {
         try {
             this.connection = await amqp.connect(BROKER_URL);
             this.channel = await this.connection.createChannel();
             await this.channel.assertQueue(SCAN_QUEUE, { durable: true });
-            logger.info('[QueueService] RabbitMQ connected and queue asserted.');
+            logger.info('[QueueService] RabbitMQ connected and queue asserted successfully.');
         } catch (error) {
-            logger.error('[QueueService] Failed to connect to RabbitMQ:', error);
-            setTimeout(() => this.connect(), 5000);
+            logger.error('[QueueService] Failed to connect to RabbitMQ:', error.message);
+            // Re-throw the error to prevent the application from starting
+            throw error;
         }
     }
 


### PR DESCRIPTION
## Summary
- configure RabbitMQ credentials in `.env` and `.env.example`
- reference correct `Files` table in ScanTask model
- make queue service initialization explicit and reliable
- start queue service before launching Express server

## Testing
- `npm test` *(fails: turbo not found)*
- `cd express && npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861dd7fe7348324889ce2a85d37bec3