### PR TITLE
Add background worker service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
     build:
       context: ./express
       dockerfile: Dockerfile
+    command: node server.js
     ports:
       - "3000:3000"
     env_file:
@@ -60,11 +61,15 @@ services:
     depends_on:
       suzoo_postgres:
         condition: service_healthy
+      suzoo_rabbitmq:
+        condition: service_healthy
       suzoo_ipfs:
         condition: service_healthy
       suzoo_ganache:
         condition: service_healthy
       suzoo_fastapi:
+        condition: service_healthy
+      milvus:
         condition: service_healthy
     networks:
       - suzoo-network
@@ -76,6 +81,46 @@ services:
       timeout: 5s
       retries: 5
       start_period: 60s
+    restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  # ----------------------------------------------------
+  # 背景任務工人 (Node.js Background Worker)
+  # ----------------------------------------------------
+  suzoo_worker:
+    container_name: suzoo_worker
+    build:
+      context: ./express
+      dockerfile: Dockerfile
+    command: node worker.js
+    env_file:
+      - .env
+    volumes:
+      - ./express:/app
+      - /app/node_modules
+      - ./uploads:/app/uploads
+      - ./credentials:/app/credentials:ro
+    depends_on:
+      suzoo_postgres:
+        condition: service_healthy
+      suzoo_rabbitmq:
+        condition: service_healthy
+      suzoo_ipfs:
+        condition: service_healthy
+      suzoo_ganache:
+        condition: service_healthy
+      suzoo_fastapi:
+        condition: service_healthy
+      milvus:
+        condition: service_healthy
+    networks:
+      - suzoo-network
+    dns:
+      - 8.8.8.8
     restart: always
     logging:
       driver: "json-file"

--- a/express/worker.js
+++ b/express/worker.js
@@ -1,0 +1,102 @@
+// express/worker.js
+// This is the background worker process that consumes tasks from RabbitMQ.
+
+// Initialize all services and database connections first.
+require('dotenv').config();
+const db = require('./models');
+const logger = require('./utils/logger');
+const queueService = require('./services/queue.service');
+const scannerService = require('./services/scanner.service');
+const { ScanTask, File } = require('./models');
+const ipfsService = require('./services/ipfsService');
+const vectorSearchService = require('./services/vectorSearch');
+
+async function processScanTask(task) {
+    const { taskId, fileId } = task;
+    logger.info(`[Worker] Received task ${taskId}: Processing scan for File ID ${fileId}`);
+
+    let scanRecord;
+    try {
+        // 1. Find the scan task record and file record from the database
+        scanRecord = await ScanTask.findByPk(taskId);
+        if (!scanRecord) {
+            throw new Error(`Scan task with ID ${taskId} not found.`);
+        }
+        await scanRecord.update({ status: 'PROCESSING', started_at: new Date() });
+
+        const fileRecord = await File.findByPk(fileId);
+        if (!fileRecord) {
+            throw new Error(`File record with ID ${fileId} not found.`);
+        }
+
+        // 2. Retrieve the image buffer from IPFS
+        logger.info(`[Worker] Task ${taskId}: Retrieving image from IPFS with hash ${fileRecord.ipfs_hash}`);
+        const imageBuffer = await ipfsService.getFile(fileRecord.ipfs_hash);
+        if (!imageBuffer) {
+            throw new Error('Failed to retrieve image from IPFS.');
+        }
+
+        // 3. Perform the full scan
+        logger.info(`[Worker] Task ${taskId}: Performing full scan...`);
+        const scanResults = await scannerService.performFullScan({
+            buffer: imageBuffer,
+            originalFingerprint: fileRecord.fingerprint,
+        });
+
+        // 4. Perform internal vector search (if needed, or combine with main scan)
+        logger.info(`[Worker] Task ${taskId}: Performing internal vector search...`);
+        const vectorMatches = await vectorSearchService.searchLocalImage(imageBuffer);
+
+        const finalResults = {
+            scan: scanResults,
+            internalMatches: vectorMatches
+        };
+
+        // 5. Update the file and scan records with the results
+        logger.info(`[Worker] Task ${taskId}: Scan complete. Saving results to database.`);
+        fileRecord.status = 'scanned';
+        fileRecord.resultJson = JSON.stringify(finalResults);
+        await fileRecord.save();
+
+        await scanRecord.update({
+            status: 'COMPLETED',
+            completed_at: new Date(),
+            result_json: finalResults
+        });
+
+        logger.info(`[Worker] Task ${taskId}: Successfully processed scan for File ID ${fileId}.`);
+        return true; // Acknowledge the message
+
+    } catch (error) {
+        logger.error(`[Worker] Task ${taskId}: FAILED to process scan for File ID ${fileId}. Error: ${error.message}`);
+        logger.error(error.stack);
+        if (scanRecord) {
+            await scanRecord.update({
+                status: 'FAILED',
+                completed_at: new Date(),
+                error_message: error.message
+            });
+        }
+        return false; // Reject the message (or requeue based on strategy)
+    }
+}
+
+async function startWorker() {
+    try {
+        logger.info('[Worker] Starting up...');
+        await db.connectToDatabase();
+        logger.info('[Worker] Database connection has been established successfully.');
+        await queueService.connect();
+        logger.info('[Worker] RabbitMQ connection has been established successfully.');
+
+        // Start consuming tasks from the 'scan_queue'
+        queueService.consumeTasks(processScanTask);
+        logger.info('[Worker] Worker is running and waiting for tasks. To exit press CTRL+C');
+
+    } catch (error) {
+        logger.error('[Worker] Failed to start:', error);
+        process.exit(1);
+    }
+}
+
+startWorker();


### PR DESCRIPTION
## Summary
- introduce `worker.js` to process scan tasks from RabbitMQ
- extend `queue.service.js` with connect and consume helpers
- start new `suzoo_worker` container via docker-compose

## Testing
- `npm test` *(fails: Vision test requires dependencies)*
- `docker compose up -d --build` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861e2084ac48324a4a2e1620b6f9f59