### PR TITLE
Add Scan model and migration

### DIFF
--- a/express/migrations/20250630015331-create-scans.js
+++ b/express/migrations/20250630015331-create-scans.js
@@ -1,0 +1,52 @@
+'use strict';
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('Scans', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      file_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'Files', // This assumes your files table is named 'Files'
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      status: {
+        type: Sequelize.ENUM('pending', 'processing', 'completed', 'failed'),
+        defaultValue: 'pending',
+        allowNull: false
+      },
+      result: {
+        type: Sequelize.JSONB,
+        allowNull: true
+      },
+      started_at: {
+        type: Sequelize.DATE
+      },
+      completed_at: {
+        type: Sequelize.DATE
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      }
+    });
+  },
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('Scans');
+  }
+};

--- a/express/models/index.js
+++ b/express/models/index.js
@@ -24,6 +24,7 @@ const db = {};
 db.User = require('./User')(sequelize, DataTypes);
 db.File = require('./File')(sequelize, DataTypes);
 db.ScanTask = require('./ScanTask')(sequelize, DataTypes);
+db.Scan = require('./scan')(sequelize, DataTypes);
 // 如果未來有其他模型，例如 Payment.js，請在此處手動加入：
 // db.Payment = require('./Payment')(sequelize, DataTypes);
 

--- a/express/models/scan.js
+++ b/express/models/scan.js
@@ -1,0 +1,44 @@
+'use strict';
+const { Model } = require('sequelize');
+
+module.exports = (sequelize, DataTypes) => {
+  class Scan extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      // define association here
+      Scan.belongsTo(models.File, {
+        foreignKey: 'file_id',
+        as: 'file'
+      });
+    }
+  }
+  Scan.init({
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true
+    },
+    file_id: {
+      type: DataTypes.INTEGER,
+      allowNull: false
+    },
+    status: {
+      type: DataTypes.ENUM('pending', 'processing', 'completed', 'failed'),
+      defaultValue: 'pending',
+      allowNull: false
+    },
+    result: {
+      type: DataTypes.JSONB
+    },
+    started_at: DataTypes.DATE,
+    completed_at: DataTypes.DATE
+  }, {
+    sequelize,
+    modelName: 'Scan',
+  });
+  return Scan;
+};


### PR DESCRIPTION
## Summary
- create `express/migrations/20250630015331-create-scans.js`
- add new Sequelize model `Scan` under `express/models/scan.js`
- register `Scan` model in `express/models/index.js`

## Testing
- `npx sequelize-cli db:migrate` *(fails: Unable to resolve sequelize package)*

------
https://chatgpt.com/codex/tasks/task_e_6861edd1dc248324a8dea850d0dfbf49