### PR TITLE
Improve IPFS client config

### DIFF
--- a/.env
+++ b/.env
@@ -47,8 +47,10 @@ CONTRACT_ADDRESS=0x590CC0a45103883cEa6E27c9a4Cc356De6384aeb
 ########################################
 # IPFS
 ########################################
-# **FIX**: Changed to hostname only for Python compatibility
-IPFS_API_URL=suzoo_ipfs
+# **FIX**: Replace the single URL with separate host, port, and protocol variables
+IPFS_HOST=suzoo_ipfs
+IPFS_PORT=5001
+IPFS_PROTOCOL=http
 
 ########################################
 # Milvus 向量資料庫

--- a/express/services/ipfsService.js
+++ b/express/services/ipfsService.js
@@ -1,4 +1,4 @@
-// express/services/ipfsService.js (Final, Simplified & Corrected Version)
+// express/services/ipfsService.js (Final Robust Version)
 const { create } = require('ipfs-http-client');
 const logger = require('../utils/logger');
 
@@ -10,18 +10,19 @@ class IpfsService {
 
   init() {
     try {
-      const url = process.env.IPFS_API_URL || 'http://suzoo_ipfs:5001';
+      // **FIX**: Read separate environment variables for robust configuration.
+      const host = process.env.IPFS_HOST || 'suzoo_ipfs';
+      const port = parseInt(process.env.IPFS_PORT || '5001', 10);
+      const protocol = process.env.IPFS_PROTOCOL || 'http';
 
-      // **FIX**: Let the ipfs-http-client handle the URL parsing directly.
-      // This is more robust and avoids the 'Invalid URL' error if a multiaddress
-      // string is used in the .env file.
-      this.client = create(url);
+      // **FIX**: Initialize the client with a configuration object instead of a URL string.
+      // This is the most reliable method and avoids all URL parsing issues.
+      this.client = create({ host, port, protocol });
 
-      logger.info(`[ipfsService] IPFS client configured for: ${url}`);
+      logger.info(`[ipfsService] IPFS client configured for ${protocol}://${host}:${port}`);
       logger.info('[ipfsService] init => client created.');
     } catch (error) {
       logger.error('[ipfsService] Failed to initialize IPFS client:', error);
-      // Ensure client is null if initialization fails
       this.client = null;
     }
   }
@@ -50,12 +51,10 @@ class IpfsService {
     logger.info(`[ipfsService.getFile] Fetching CID: ${cid}`);
     try {
       const chunks = [];
-      // The 'cat' method returns an async iterator. We need to collect all chunks.
       for await (const chunk of this.client.cat(cid)) {
         chunks.push(chunk);
       }
 
-      // Concatenate all chunks into a single, standard Node.js Buffer.
       const fileBuffer = Buffer.concat(chunks);
       logger.info(`[ipfsService.getFile] Successfully fetched ${fileBuffer.length} bytes for CID: ${cid}`);
 


### PR DESCRIPTION
## Summary
- split IPFS config into `IPFS_HOST`, `IPFS_PORT` and `IPFS_PROTOCOL`
- configure IPFS client using these settings in `ipfsService`

## Testing
- `pnpm install` *(fails: telemetry.vercel.com blocked)*
- `pnpm test` *(fails: suzoo-express tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6861fa9b63488324bb65c6ca116c75c9