### PR TITLE
Add scan status API

### DIFF
--- a/express/routes/scans.js
+++ b/express/routes/scans.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const router = express.Router();
+const db = require('../models');
+const logger = require('../utils/logger');
+
+/**
+ * GET /api/scans/status/:taskId
+ * Checks the status and result of a specific scan task.
+ */
+router.get('/status/:taskId', async (req, res) => {
+    const { taskId } = req.params;
+
+    if (!taskId) {
+        return res.status(400).json({ error: 'Task ID is required.' });
+    }
+
+    try {
+        const scan = await db.Scan.findByPk(taskId);
+
+        if (!scan) {
+            return res.status(404).json({ error: `Scan task with ID ${taskId} not found.` });
+        }
+
+        res.status(200).json({
+            taskId: scan.id,
+            fileId: scan.file_id,
+            status: scan.status,
+            result: scan.result,
+            createdAt: scan.createdAt,
+            completedAt: scan.completed_at,
+        });
+
+    } catch (error) {
+        logger.error(`[Scan Status API] Failed to get status for task ID ${taskId}:`, error);
+        res.status(500).json({ error: 'Failed to retrieve scan status.' });
+    }
+});
+
+module.exports = router;

--- a/express/server.js
+++ b/express/server.js
@@ -26,6 +26,7 @@ const reportRouter = require('./routes/report');
 const infringementRouter = require('./routes/infringement');
 const paymentRoutes = require('./routes/paymentRoutes');
 const searchMilvusRouter = require('./routes/searchMilvus');
+const scanRoutes = require('./routes/scans'); // newly added route for scan status
 
 const app = express();
 
@@ -51,6 +52,7 @@ app.use('/api/report', reportRouter);
 app.use('/api/infringement', infringementRouter);
 app.use('/api/payment', paymentRoutes);
 app.use('/api/milvus', searchMilvusRouter);
+app.use('/api/scans', scanRoutes); // route handling scan status queries
 
 // --- 健康檢查路由 ---
 app.get('/health', (req, res) => {


### PR DESCRIPTION
## Summary
- create `express/routes/scans.js` for checking scan task status
- register the new `/api/scans` route in `express/server.js`

## Testing
- `pnpm test` *(fails: sharp module missing and vision test fails)*

------
https://chatgpt.com/codex/tasks/task_e_6861ff5483f4832494a9b3ffa26b5cd4