### PR TITLE
Add internal AI match display

### DIFF
--- a/express/routes/files.js
+++ b/express/routes/files.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const router = express.Router();
+const db = require('../models');
+
+// GET /api/files/:fileId - return basic file info
+router.get('/:fileId', async (req, res) => {
+  const { fileId } = req.params;
+  if (!fileId) {
+    return res.status(400).json({ error: 'File ID is required.' });
+  }
+  try {
+    const file = await db.File.findByPk(fileId);
+    if (!file) {
+      return res.status(404).json({ error: 'File not found.' });
+    }
+    return res.json({
+      id: file.id,
+      title: file.title,
+      filename: file.filename,
+      mimeType: file.mime_type,
+      userId: file.user_id
+    });
+  } catch (err) {
+    console.error('[File Info Error]', err);
+    return res.status(500).json({ error: 'Failed to retrieve file info.' });
+  }
+});
+
+module.exports = router;

--- a/express/server.js
+++ b/express/server.js
@@ -27,6 +27,7 @@ const infringementRouter = require('./routes/infringement');
 const paymentRoutes = require('./routes/paymentRoutes');
 const searchMilvusRouter = require('./routes/searchMilvus');
 const scanRoutes = require('./routes/scans'); // newly added route for scan status
+const filesRouter = require('./routes/files');
 
 const app = express();
 
@@ -53,6 +54,7 @@ app.use('/api/infringement', infringementRouter);
 app.use('/api/payment', paymentRoutes);
 app.use('/api/milvus', searchMilvusRouter);
 app.use('/api/scans', scanRoutes); // route handling scan status queries
+app.use('/api/files', filesRouter);
 
 // --- 健康檢查路由 ---
 app.get('/health', (req, res) => {

--- a/frontend/src/pages/ProtectStep3.jsx
+++ b/frontend/src/pages/ProtectStep3.jsx
@@ -112,6 +112,25 @@ export default function ProtectStep3() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [step1Data, setStep1Data] = useState(null);
+  const [internalMatches, setInternalMatches] = useState([]);
+  const [fileInfoMap, setFileInfoMap] = useState({});
+
+  const highSimilarityMatches = internalMatches.filter(m => m.score >= 0.8);
+
+  useEffect(() => {
+    highSimilarityMatches.forEach(match => {
+      if (!fileInfoMap[match.id]) {
+        fetch(`/api/files/${match.id}`)
+          .then(res => res.ok ? res.json() : null)
+          .then(data => {
+            if (data) {
+              setFileInfoMap(prev => ({ ...prev, [match.id]: data }));
+            }
+          })
+          .catch(() => {});
+      }
+    });
+  }, [highSimilarityMatches]);
 
   useEffect(() => {
     const storedData = localStorage.getItem('protectStep1');
@@ -167,7 +186,8 @@ export default function ProtectStep3() {
         if (data.status === 'completed') {
           const parsed = typeof data.result === 'string' ? JSON.parse(data.result) : data.result;
           setScanResult(parsed.scan);
-          localStorage.setItem('protectStep3', JSON.stringify({ scanResults: parsed.scan }));
+          setInternalMatches(parsed.internalMatches?.results || []);
+          localStorage.setItem('protectStep3', JSON.stringify({ scanResults: parsed.scan, internalMatches: parsed.internalMatches }));
           clearInterval(timer);
           setLoading(false);
         } else if (data.status === 'failed') {
@@ -211,6 +231,30 @@ export default function ProtectStep3() {
     }
   };
 
+  const handleDMCATakedown = async(matchId) => {
+    if(!window.confirm('確定要對此相似圖片提出 DMCA 申訴嗎？')) return;
+    try {
+      const res = await fetch('/api/dmca/report', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          workId: step1Data?.fileId,
+          infringingUrl: `/api/protect/view/${matchId}`
+        })
+      });
+      const data = await res.json();
+      if(res.ok){
+        alert('DMCA 已提交');
+      }else{
+        alert(`失敗: ${data.error || '未知錯誤'}`);
+      }
+    } catch(e){
+      alert(`錯誤: ${e.message}`);
+    }
+  };
+
   const renderContent = () => {
     if (loading) {
       return (
@@ -236,25 +280,57 @@ export default function ProtectStep3() {
       const allLinks = [...googleLinks, ...tineyeLinks];
 
       return (
-        <InfoBlock>
-          <p style={{ fontWeight: 'bold', marginBottom: '1rem' }}>偵測完成！</p>
-          {allLinks.length > 0 ? (
-            <>
-              <p>發現 {allLinks.length} 個潛在的侵權或相似圖片連結：</p>
-              <ul style={{ maxHeight: '200px', overflowY: 'auto', paddingLeft: '20px' }}>
-                {allLinks.map((item, idx) => (
-                  <li key={idx} style={{ margin: '0.5rem 0' }}>
-                    <a href={item.url} target="_blank" rel="noopener noreferrer" style={{ color: '#4caf50' }}>
-                      {item.source}: {item.url}
-                    </a>
-                  </li>
+        <>
+          <InfoBlock>
+            <p style={{ fontWeight: 'bold', marginBottom: '1rem' }}>偵測完成！</p>
+            {allLinks.length > 0 ? (
+              <>
+                <p>發現 {allLinks.length} 個潛在的侵權或相似圖片連結：</p>
+                <ul style={{ maxHeight: '200px', overflowY: 'auto', paddingLeft: '20px' }}>
+                  {allLinks.map((item, idx) => (
+                    <li key={idx} style={{ margin: '0.5rem 0' }}>
+                      <a href={item.url} target="_blank" rel="noopener noreferrer" style={{ color: '#4caf50' }}>
+                        {item.source}: {item.url}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </>
+            ) : (
+              <p>恭喜！初步掃描未在各大平台發現相似的公開圖片。</p>
+            )}
+          </InfoBlock>
+
+          <div className="ai-matches-section" style={{ marginTop: '1rem' }}>
+            <h3>內部資料庫 AI 相似度匹配 (待審核)</h3>
+            {highSimilarityMatches.length > 0 ? (
+              <div className="matches-grid" style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
+                {highSimilarityMatches.map(match => (
+                  <div key={match.id} className="match-card" style={{ border: '1px solid #555', padding: '0.5rem', borderRadius: '6px' }}>
+                    <img
+                      src={`/api/protect/view/${match.id}`}
+                      alt={`Similar image with ID ${match.id}`}
+                      className="preview-image"
+                      style={{ maxWidth: '120px', display: 'block', marginBottom: '0.5rem' }}
+                    />
+                    <div className="match-info" style={{ fontSize: '0.9rem', marginBottom: '0.25rem' }}>
+                      <p><strong>檔案 ID:</strong> {match.id}</p>
+                      <p><strong>相似度:</strong> {(match.score * 100).toFixed(1)}%</p>
+                      {fileInfoMap[match.id]?.title && (
+                        <p><strong>標題:</strong> {fileInfoMap[match.id].title}</p>
+                      )}
+                    </div>
+                    <div className="match-actions" style={{ textAlign: 'center' }}>
+                      <button onClick={() => handleDMCATakedown(match.id)}>發送 DMCA 申訴</button>
+                    </div>
+                  </div>
                 ))}
-              </ul>
-            </>
-          ) : (
-            <p>恭喜！初步掃描未在各大平台發現相似的公開圖片。</p>
-          )}
-        </InfoBlock>
+              </div>
+            ) : (
+              <p>在內部資料庫中未找到相似度高於 80% 的圖片。</p>
+            )}
+          </div>
+        </>
       );
     }
 


### PR DESCRIPTION
## Summary
- expose file info API on the Express server
- register `/api/files` route in `server.js`
- show internal vector search results on ProtectStep3 page with DMCA action

## Testing
- `npm test` *(fails: turbo not found)*
- `cd express && npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686208179ce88324999c3cc3fe71bb4b