### PR TITLE
Fix Step3 result parsing

### DIFF
--- a/frontend/src/pages/ProtectStep3.jsx
+++ b/frontend/src/pages/ProtectStep3.jsx
@@ -102,7 +102,8 @@ export default function ProtectStep3() {
         if (data.status === 'completed') {
           clearInterval(timer);
           setLoading(false);
-          setScanResult(data.result);
+          const resultData = typeof data.result === 'string' ? JSON.parse(data.result) : data.result;
+          setScanResult(resultData);
         } else if (data.status === 'failed') {
           clearInterval(timer);
           setLoading(false);


### PR DESCRIPTION
## Summary
- parse JSON string from scan status API before using data in ProtectStep3 page

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862aac1cd50832497a479cfa35458c6