### PR TITLE
Fix etcd logging option

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -231,7 +231,7 @@ services:
       driver: "json-file"
       options:
         max-size: "10m"
-      max-file: "3"
+        max-file: "3"
 
   # -------------------------------------
   # MinIO (Object Storage for Milvus)


### PR DESCRIPTION
## Summary
- fix indentation for etcd logging configuration in docker-compose

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68634aec8ba48324aa0bf1fc8468bda2