### PR TITLE
Fix optional chaining for build

### DIFF
--- a/frontend/src/pages/ProtectStep2.jsx
+++ b/frontend/src/pages/ProtectStep2.jsx
@@ -122,7 +122,9 @@ export default function ProtectStep2() {
   const location = useLocation();
 
   // 優先從 location.state 獲取數據，其次才從 localStorage 獲取
-  const [step1Data, setStep1Data] = useState(location.state?.step1Data || null);
+  const [step1Data, setStep1Data] = useState(
+    location.state && location.state.step1Data ? location.state.step1Data : null
+  );
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
@@ -140,7 +142,7 @@ export default function ProtectStep2() {
   }, [step1Data, navigate]);
 
   const handleProceedToScan = async () => {
-    if (!step1Data?.file?.id) {
+    if (!(step1Data && step1Data.file && step1Data.file.id)) {
       alert('錯誤：無效的檔案資訊，無法啟動掃描。');
       return;
     }

--- a/frontend/src/pages/ProtectStep3.jsx
+++ b/frontend/src/pages/ProtectStep3.jsx
@@ -115,13 +115,13 @@ const extractLinks = (result) => {
     }
     const { googleVision, tineye, bing } = result.scan.reverseImageSearch;
     const links = [];
-    if (googleVision?.success && Array.isArray(googleVision.links)) {
+    if (googleVision && googleVision.success && Array.isArray(googleVision.links)) {
         googleVision.links.forEach(url => links.push({ source: 'Google', url }));
     }
-    if (tineye?.success && Array.isArray(tineye.matches)) {
+    if (tineye && tineye.success && Array.isArray(tineye.matches)) {
         tineye.matches.forEach(match => links.push({ source: 'TinEye', url: match.url }));
     }
-    if (bing?.success && Array.isArray(bing.links)) {
+    if (bing && bing.success && Array.isArray(bing.links)) {
         bing.links.forEach(url => links.push({ source: 'Bing', url }));
     }
     // Remove duplicate URLs
@@ -146,7 +146,9 @@ export default function ProtectStep3() {
     const [taskStatus, setTaskStatus] = useState('pending');
 
     const { taskId } = location.state || {};
-    const [step1Data, setStep1Data] = useState(location.state?.step1Data || null);
+    const [step1Data, setStep1Data] = useState(
+        location.state && location.state.step1Data ? location.state.step1Data : null
+    );
 
     useEffect(() => {
         if (!step1Data) {
@@ -185,7 +187,7 @@ export default function ProtectStep3() {
                     setLoading(false);
                     if (data.status === 'failed') {
                         const errData = typeof data.result === 'string' ? JSON.parse(data.result) : data.result;
-                        setError(errData?.error || '掃描任務執行失敗');
+                        setError((errData && errData.error) || '掃描任務執行失敗');
                     }
                 }
             } catch (err) {


### PR DESCRIPTION
## Summary
- remove optional chaining from ProtectStep2 and ProtectStep3 to avoid parser errors

## Testing
- `node - <<'EOF'
const fs=require('fs');const parser=require('@babel/parser');const opts={sourceType:'module',plugins:['jsx']};
try{parser.parse(fs.readFileSync('frontend/src/pages/ProtectStep2.jsx','utf8'),opts);console.log('OK2');}catch(e){console.error(e.message,e.loc);}
try{parser.parse(fs.readFileSync('frontend/src/pages/ProtectStep3.jsx','utf8'),opts);console.log('OK3');}catch(e){console.error(e.message,e.loc);}
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6863a0d00b0c8324ae60d52a20e6219f