### PR TITLE
Fix Dockerfile parse error

### DIFF
--- a/fastapi/Dockerfile
+++ b/fastapi/Dockerfile
@@ -11,7 +11,8 @@ from transformers import CLIPProcessor, CLIPModel
 CLIPModel.from_pretrained("openai/clip-vit-base-patch32")
 CLIPProcessor.from_pretrained("openai/clip-vit-base-patch32")
 EOF
-    && pip show uvicorn  # 明確檢查uvicorn安裝成功
+
+RUN pip show uvicorn  # 明確檢查uvicorn安裝成功
 
 # 複製 FastAPI 專案程式碼
 COPY . .


### PR DESCRIPTION
## Summary
- adjust fastapi Dockerfile to avoid dangling `&&`

## Testing
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863ba24d728832495d5feb715bcb883