### PR TITLE
Fix Milvus container health check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -193,7 +193,9 @@ services:
       etcd:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9091/api/v1/health"]
+      # Milvus exposes a simple healthz endpoint on the HTTP port
+      # Using /healthz avoids API changes across versions
+      test: ["CMD", "curl", "-f", "http://localhost:9091/healthz"]
       interval: 10s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
## Summary
- update Milvus healthcheck endpoint so container becomes healthy

## Testing
- `npm install`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863c0e5640c8324947d0a683a0951eb