### PR TITLE
Fix Milvus startup when ROCKSMQ lock file exists

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,12 +172,14 @@ services:
   milvus:
     container_name: suzoo_milvus
     image: milvusdb/milvus:${MILVUS_IMAGE_TAG:-v2.3.16}
-    command: ["milvus", "run", "standalone"]
+    # Ensure any stale RocksMQ lock files are cleaned before startup
+    command: ["bash", "/start_milvus.sh"]
     ports:
       - "19530:19530"
       - "9091:9091"
     volumes:
       - milvus_data:/var/lib/milvus
+      - ./scripts/start_milvus.sh:/start_milvus.sh:ro
     networks:
       - suzoo-network
     environment:

--- a/scripts/start_milvus.sh
+++ b/scripts/start_milvus.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+LOCK_DIR=/var/lib/milvus
+# remove possible leftover RocksMQ lock files
+rm -f "$LOCK_DIR/rdb_data_meta_kv/LOCK" || true
+rm -f "$LOCK_DIR/rdb_data"/*.lock || true
+exec milvus run standalone


### PR DESCRIPTION
## Summary
- add script to clean up RocksMQ lock files before starting Milvus
- run Milvus via the startup script in docker-compose

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6863c2c3cb708324a1ce113bc2048051