### PR TITLE
Update Milvus healthcheck

### DIFF
--- a/.env
+++ b/.env
@@ -56,7 +56,7 @@ IPFS_PROTOCOL=http
 ########################################
 MILVUS_HOST=milvus
 MILVUS_PORT=19530
-MILVUS_IMAGE_TAG=v2.3.16
+MILVUS_IMAGE_TAG=v2.4.4-20240531-8e7f36d9-amd64
 
 ########################################
 # RabbitMQ / Celery

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -197,7 +197,7 @@ services:
     healthcheck:
       # Milvus exposes a simple healthz endpoint on the HTTP port
       # Using /healthz avoids API changes across versions
-      test: ["CMD", "curl", "-f", "http://localhost:9091/healthz"]
+      test: ["CMD", "python", "-c", "import urllib.request,sys; u=urllib.request.urlopen('http://localhost:9091/healthz', timeout=5); sys.exit(0 if u.status==200 else 1)"]
       interval: 10s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
## Summary
- ensure Milvus uses a Python-based healthcheck
- bump `MILVUS_IMAGE_TAG` to match example

## Testing
- `npm test` *(fails: `turbo` not found)*
- `docker compose up -d milvus` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863d457453083249ce96cb7e9d6b387