### PR TITLE
Fix milvus image tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
-# docker-compose.yml (最終正確版)
-# 已修正 Milvus 啟動方式並增加共享記憶體
+# docker-compose.yml (真正最終版)
+# 強制使用 Milvus v2.3.16 穩定版映像檔，不再讀取 .env 變數
 
 networks:
   suzoo-network:
@@ -171,7 +171,7 @@ services:
   # -------------------------------------
   milvus:
     container_name: suzoo_milvus
-    image: milvusdb/milvus:${MILVUS_IMAGE_TAG:-v2.3.16}
+    image: milvusdb/milvus:v2.3.16
     ports:
       - "19530:19530"
       - "9091:9091"


### PR DESCRIPTION
## Summary
- lock Milvus service image to v2.3.16
- update top-level comments describing the change

## Testing
- `pnpm install` *(fails: ignored build scripts blocked)*
- `pnpm test` *(fails: sharp module install error)*

------
https://chatgpt.com/codex/tasks/task_e_6863f153ef288324af40e68ca341b5df