### PR TITLE
Fix Milvus startup dependency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,6 +194,8 @@ services:
     depends_on:
       suzoo_minio:
         condition: service_healthy
+      suzoo_etcd:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:9091/healthz"]
       interval: 10s


### PR DESCRIPTION
## Summary
- ensure Milvus waits for etcd to be healthy before starting

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686423b0806c832486ac5f292b21d9c6