### PR TITLE
Fix Milvus depends_on service name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,7 +194,7 @@ services:
     depends_on:
       suzoo_minio:
         condition: service_healthy
-      suzoo_etcd:
+      etcd:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:9091/healthz"]


### PR DESCRIPTION
## Summary
- correct the service name referenced by Milvus in `docker-compose.yml`

## Testing
- `docker compose version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864257f004883248b302e7662f44b03