### PR TITLE
Fix user field names

### DIFF
--- a/express/createDefaultAdmin.js
+++ b/express/createDefaultAdmin.js
@@ -66,16 +66,15 @@ module.exports = async function createDefaultAdmin() {
     // 若不存在 => 新建 admin
     logger.info(`[AdminSetup] No existing admin found. Creating a new admin user with email: ${defaultEmail}`);
     const hashed = await bcrypt.hash(defaultPass, 10);
-    await User.create({
-      serialNumber: 'SNADMIN001',
-      email: defaultEmail,
-      phone: defaultPhone,
-      password: hashed,
-      role: 'admin',
-      name: 'System Admin', // 使用 'name' 欄位
-      realName: 'System Admin', // 保留您原有的 realName
-      username: 'admin_user' // 提供一個預設 username
-    });
+      await User.create({
+        serialNumber: 'SNADMIN001',
+        email: defaultEmail,
+        phone: defaultPhone,
+        password: hashed,
+        role: 'admin',
+        realName: 'System Admin',
+        username: 'admin_user'
+      });
     logger.info(`[AdminSetup] New admin user created successfully with email: ${defaultEmail}`);
 
   } catch (err) {

--- a/express/routes/protect.js
+++ b/express/routes/protect.js
@@ -61,7 +61,7 @@ router.post('/step1', upload.single('file'), async (req, res) => {
                 fs.unlinkSync(tempPath);
                 return res.status(400).json({ error: '對於新用戶，姓名和電子郵件為必填項。'});
             }
-            user = await User.create({ name: realName, dob: birthDate, phone, address, email });
+            user = await User.create({ realName, birthDate, phone, address, email });
             logger.info(`[Step 1] New user created: ${user.email} (ID: ${user.id})`);
         }
 

--- a/express/routes/users.js
+++ b/express/routes/users.js
@@ -7,7 +7,7 @@ router.get('/:userId', async (req, res) => {
   const { userId } = req.params;
   try {
     const user = await db.User.findByPk(userId, {
-      attributes: ['id', 'name', 'email', 'phone']
+      attributes: ['id', 'realName', 'email', 'phone']
     });
     if (!user) {
       return res.status(404).json({ error: 'User not found' });


### PR DESCRIPTION
## Summary
- fix admin creation to use `realName`
- create user with `birthDate` field
- use `realName` in users route

## Testing
- `pnpm test` *(fails: turbo not found)*
- `pnpm lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643271ffdc832491f056c681a300f2