### PR TITLE
Fix milvus startup using init script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -179,8 +179,10 @@ services:
     shm_size: '2gb'
     volumes:
       - milvus_data:/var/lib/milvus
+      - ./scripts/start_milvus.sh:/start_milvus.sh:ro
     networks:
       - suzoo-network
+    entrypoint: ["/bin/bash", "/start_milvus.sh"]
     environment:
       ETCD_ENDPOINTS: etcd:2379
       MINIO_ADDRESS: suzoo_minio:9000
@@ -198,7 +200,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 10
-      start_period: 30s
+      start_period: 60s
     restart: always
     logging:
       driver: "json-file"


### PR DESCRIPTION
## Summary
- add start_milvus wrapper script to docker-compose
- call the script as the container entrypoint
- give Milvus more time before healthcheck starts

## Testing
- `pnpm test` *(fails: turbo not found)*
- `npx turbo run test` *(fails: lockfile not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864d9c4092083249e850a6cab3eb203