### PR TITLE
Fix milvus startup

### DIFF
--- a/scripts/start_milvus.sh
+++ b/scripts/start_milvus.sh
@@ -1,5 +1,9 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Starting custom Milvus script..."
+echo "ETCD_ENDPOINTS=${ETCD_ENDPOINTS:-}"
+echo "MINIO_ADDRESS=${MINIO_ADDRESS:-}"
 
 LOCK_DIR=/var/lib/milvus
 


### PR DESCRIPTION
## Summary
- update milvus startup script to ensure it runs with env bash and more safety

## Testing
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864db51e2948324afc43313fbdbb1b8