### PR TITLE
Improve Milvus healthcheck startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -183,7 +183,7 @@ services:
     volumes:
       - milvus_data:/var/lib/milvus
       # [HYBRID FIX] 將啟動腳本掛載到容器中
-      - ./scripts/start_milvus.sh:/start_milvus.sh
+      - ./scripts/start_milvus.sh:/start_milvus.sh:ro
     networks:
       - suzoo-network
     environment:
@@ -202,8 +202,8 @@ services:
       test: ["CMD", "curl", "--fail", "http://localhost:9091/healthz"]
       interval: 10s
       timeout: 5s
-      retries: 10
-      start_period: 30s
+      retries: 15
+      start_period: 60s
     restart: always
     logging:
       driver: "json-file"

--- a/scripts/start_milvus.sh
+++ b/scripts/start_milvus.sh
@@ -22,7 +22,10 @@ wait_for() {
   echo "$name is available"
 }
 
+echo "$(date) - Waiting for etcd service..."
 wait_for "etcd" "http://${ETCD_ENDPOINTS}/health"
+echo "$(date) - Waiting for MinIO service..."
 wait_for "minio" "http://${MINIO_ADDRESS}/minio/health/ready"
 
+echo "$(date) - Starting Milvus in standalone mode"
 exec milvus run standalone


### PR DESCRIPTION
## Summary
- enhance start_milvus.sh logging for startup troubleshooting
- mount the script read-only and relax Milvus healthcheck timing

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864efd2ab6883249fc007a6817ed947