### PR TITLE
Fix milvus startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,12 +169,14 @@ services:
   milvus:
     container_name: suzoo_milvus
     image: milvusdb/milvus:v2.3.16
+    entrypoint: ["/bin/bash", "/start_milvus.sh"]
     ports:
       - "19530:19530"
       - "9091:9091"
     shm_size: '2gb'
     volumes:
       - milvus_data:/var/lib/milvus
+      - ./scripts/start_milvus.sh:/start_milvus.sh:ro
     networks:
       - suzoo-network
     environment:


### PR DESCRIPTION
## Summary
- ensure milvus waits for dependencies by using custom wrapper script

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68650bc388988324bd2da51386019a64