### PR TITLE
Fix IPFS startup issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -338,6 +338,10 @@ services:
   suzoo_ipfs:
     container_name: suzoo_ipfs
     image: ipfs/kubo:latest
+    entrypoint:
+      - "/bin/sh"
+      - "-c"
+      - "chown -R ipfs:ipfs /data/ipfs && /sbin/tini -- /usr/local/bin/start_ipfs_daemon"
     ports:
       - "5001:5001"
       - "8080:8080"


### PR DESCRIPTION
## Summary
- ensure ipfs volume ownership is correct before starting Kubo

## Testing
- `pnpm lint` *(no tasks)*
- `pnpm test` *(failed: sharp module missing)*

------
https://chatgpt.com/codex/tasks/task_e_6865293d5cfc83248e2a6ccb19beca84