### PR TITLE
Clean up FastAPI Dockerfile and vector stubs

### DIFF
--- a/express/services/vectorSearch.js
+++ b/express/services/vectorSearch.js
@@ -13,7 +13,6 @@ const indexImage = async (fileBuffer, fileId) => {
         logger.warn(`[vectorSearchService-DISABLED] indexImage called for File ID: ${fileId}. Service is disabled, skipping.`);
         return Promise.resolve();
     }
-    // 如果未來需要重新啟用，可以在此處添加連線到新服務的邏輯
     logger.warn(`[vectorSearchService] indexImage called but no vector service is configured.`);
     return Promise.resolve();
 };
@@ -27,7 +26,6 @@ const searchLocalImage = async (imageBuffer) => {
         logger.warn('[vectorSearchService-DISABLED] searchLocalImage called. Service is disabled, skipping. Returning empty results.');
         return Promise.resolve({ success: true, matches: [] });
     }
-    // 如果未來需要重新啟用，可以在此處添加連線到新服務的邏輯
     logger.warn(`[vectorSearchService] searchLocalImage called but no vector service is configured. Returning empty results.`);
     return Promise.resolve({ success: true, matches: [] });
 };

--- a/fastapi/Dockerfile
+++ b/fastapi/Dockerfile
@@ -1,34 +1,29 @@
-# 使用官方的 Python 3.9 slim 版本作為基礎映像，體積小且穩定
+# fastapi/Dockerfile (最終無 Milvus 版本)
+
+# Stage 1: Base Image
 FROM python:3.9-slim
 
-# 在容器中建立並設定工作目錄
+# Set the working directory in the container
 WORKDIR /app
 
-# 安裝系統工具 (供健康檢查使用)
+# Install system dependencies that might be needed for Python packages
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    apt-get install -y --no-install-recommends gcc build-essential && \
+    rm -rf /var/lib/apt/lists/*
 
-# --- 安裝依賴 ---
-# 為了利用 Docker 的層快取機制，我們先只複製 requirements.txt
+# Copy and install Python dependencies
 COPY requirements.txt .
-
-# 執行 pip install 指令。
-# --no-cache-dir 參數可以減少映像檔的體積。
-# 將 pip 升級和安裝套件寫在同一個 RUN 指令中，以減少映像層數。
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
 
-# --- AI 模型預熱 (Cache Warming) ---
-# 在建置階段就下載模型，這樣服務啟動時就不再需要網路請求，會快很多。
-# 注意：這會讓你的 Docker image 體積增加數 GB。
-RUN python -c "from transformers import CLIPProcessor, CLIPModel; print('Downloading CLIP model...'); CLIPModel.from_pretrained('openai/clip-vit-base-patch32'); print('Downloading CLIP processor...'); CLIPProcessor.from_pretrained('openai/clip-vit-base-patch32'); print('Model cache warmed up.')"
+# [REMOVED] 移除預先下載 CLIP 模型的步驟
+# 因為我們不再使用 transformers 函式庫，所以這一行必須被刪除。
 
-# 將所有應用程式程式碼複製到工作目錄
+# Copy the rest of the application code
 COPY . .
 
-# 向外部開放 8000 端口
+# Expose the port the app runs on
 EXPOSE 8000
 
-# 設定容器啟動時要執行的預設指令
+# Define the command to run the application
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/fastapi/main.py
+++ b/fastapi/main.py
@@ -19,9 +19,6 @@ def shutdown_event():
     """
     print("[FastAPI] Application shutting down.")
 
-# [REMOVED] 移除了 /api/v1/image-insert 和 /api/v1/image-search 路由
-# 因為它們的功能依賴於已被棄用的 Milvus。
-
 @app.get("/health")
 def health():
     """
@@ -35,8 +32,3 @@ async def health_check():
     專為 Docker healthcheck 設計的輕量級健康檢查端點。
     """
     return {"status": "ok"}
-
-# [REMOVED] 所有與資料庫連線、Cloudinary、IPFS、Web3、PDF生成、
-# Milvus 連線、CLIP 模型載入、圖片向量化相關的函式和全域變數都已被移除，
-# 因為在此服務的職責中已不再需要它們。
-# FastAPI 服務現在是一個極簡的存根(stub)服務。


### PR DESCRIPTION
## Summary
- drop CLIP preload step from `fastapi/Dockerfile`
- trim comments from the FastAPI stub service
- clean up vector search stub logic

## Testing
- `npm run lint` *(fails: `turbo: not found`)*
- `npx jest` *(fails: network install prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68654b5eb5988324809a3f51f7ee8e48