### PR TITLE
Add Bing API fallback key logic

### DIFF
--- a/.env
+++ b/.env
@@ -86,6 +86,7 @@ DMCA_API_URL=https://api.dmca.com
 
 # --- Bing Image Search ---
 BING_API_KEY=D8ikOILi49DYgPBpq8DkD5kALZkLG87p1YeAY98cltQtdBo1sbbJJQQJ99BFAC3pKaRXJ3w3AAAEACOGrcrk
+BING_API_KEY2=1Tbng23qGt77OMBaMpamBxel29OH5xky0EmrtVoedxj72ny39YHpJQQJ99BFAC3pKaRXJ3w3AAAEACOG8nod
 BING_API_ENDPOINT=https://suzookaizokuhunter-ai-services.cognitiveservices.azure.com
 
 ########################################

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ TINEYE_API_KEY=your_tineye_api_key
 啟用 Bing 反向圖搜尋，需在 `.env` 中設定以下兩個參數：
 
 ```bash
-BING_API_KEY=your-bing-api-key
+BING_API_KEY=your-primary-bing-key
+BING_API_KEY2=your-secondary-bing-key   # optional fallback
 BING_API_ENDPOINT=https://<your-resource>.cognitiveservices.azure.com
 ```
 

--- a/express/services/bing.service.js
+++ b/express/services/bing.service.js
@@ -5,12 +5,14 @@ const { URL } = require('url'); // Import URL for robust path joining
 const logger = require('../utils/logger');
 
 const BING_API_KEY = process.env.BING_API_KEY;
+// Optional secondary key allows seamless rollover if the primary key fails
+const BING_API_KEY2 = process.env.BING_API_KEY2 || process.env.BING_API_KEY_2;
 const BING_API_ENDPOINT = process.env.BING_API_ENDPOINT;
 
 async function searchByBuffer(buffer) {
-  if (!BING_API_KEY || !BING_API_ENDPOINT) {
-    logger.warn('[Bing Service] BING_API_KEY or BING_API_ENDPOINT is not configured. Service disabled.');
-    return { success: false, links: [], error: 'Bing API key or endpoint not configured.' };
+  if (!BING_API_ENDPOINT || (!BING_API_KEY && !BING_API_KEY2)) {
+    logger.warn('[Bing Service] BING_API_KEY/BING_API_KEY2 or BING_API_ENDPOINT is not configured. Service disabled.');
+    return { success: false, links: [], error: 'Bing API credentials not configured.' };
   }
   if (!buffer) {
     return { success: false, links: [], error: 'Invalid image buffer provided.' };
@@ -18,43 +20,49 @@ async function searchByBuffer(buffer) {
 
   logger.info(`[Bing Service] Starting search by image buffer (size: ${buffer.length} bytes)...`);
 
-  const form = new FormData();
-  form.append('image', buffer, { filename: 'upload.jpg' });
+  const attempt = async (apiKey) => {
+    const form = new FormData();
+    form.append('image', buffer, { filename: 'upload.jpg' });
 
-  const headers = {
-    ...form.getHeaders(),
-    'Ocp-Apim-Subscription-Key': BING_API_KEY,
-  };
+    const headers = {
+      ...form.getHeaders(),
+      'Ocp-Apim-Subscription-Key': apiKey,
+    };
 
-  // NOTE: When using an Azure multi-service endpoint, Bing APIs require the
-  // '/bing' path prefix. Without it the service responds with `Resource not
-  // found` (HTTP 404).
-  // Ref: https://learn.microsoft.com/azure/ai-services/bing-search/bing-search-api-endpoint
-  const endpointUrl = new URL(BING_API_ENDPOINT);
-  // Use Visual Search endpoint for reverse image lookup
-  endpointUrl.pathname = '/bing/v7.0/images/visualsearch';
-  endpointUrl.searchParams.set('modules', 'SimilarImages');
+    const endpointUrl = new URL(BING_API_ENDPOINT);
+    // When using an Azure multi-service endpoint, Bing APIs require the '/bing' prefix
+    let basePath = endpointUrl.pathname.replace(/\/+$/, '');
+    if (basePath.includes('/bing')) {
+      endpointUrl.pathname = `${basePath}/v7.0/images/visualsearch`;
+    } else {
+      endpointUrl.pathname = `${basePath}/bing/v7.0/images/visualsearch`;
+    }
+    endpointUrl.searchParams.set('modules', 'SimilarImages');
 
-  const fullUrl = endpointUrl.href;
+    const fullUrl = endpointUrl.href;
 
-  try {
     const response = await axios.post(fullUrl, form, { headers, timeout: 30000 });
     const rawMatches = response.data?.similarImages?.value || [];
     const links = rawMatches.map((match) => match.hostPageUrl).filter(Boolean);
     const uniqueLinks = [...new Set(links)];
-
-    logger.info(`[Bing Service] Search complete. Found ${uniqueLinks.length} unique links.`);
+    logger.info(`[Bing Service] Search complete using provided key. Found ${uniqueLinks.length} unique links.`);
     return { success: true, links: uniqueLinks, error: null };
-  } catch (error) {
-    const errorMsg = error.response?.data?.error?.message || 'An unknown error occurred';
-    logger.error(`[Bing Service] Search failed: ${errorMsg}`, {
-      status: error.response?.status,
-      url: fullUrl,
-      // Log the response body from Bing if available, it often contains hints.
-      responseData: error.response?.data,
-    });
-    return { success: false, links: [], error: errorMsg };
+  };
+
+  const apiKeys = [BING_API_KEY, BING_API_KEY2].filter(Boolean);
+  let lastError = null;
+
+  for (let i = 0; i < apiKeys.length; i++) {
+    try {
+      return await attempt(apiKeys[i]);
+    } catch (error) {
+      const errorMsg = error.response?.data?.error?.message || error.message || 'Unknown error';
+      logger.error(`[Bing Service] Attempt ${i + 1} failed: ${errorMsg}`);
+      lastError = errorMsg;
+    }
   }
+
+  return { success: false, links: [], error: lastError || 'Failed to search image with Bing' };
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- add optional `BING_API_KEY2` in env and README
- support secondary key and dynamic endpoint path for Bing search

## Testing
- `npx -y turbo run test` *(fails: Could not resolve workspaces)*

------
https://chatgpt.com/codex/tasks/task_e_6865620d43d4832484ffc084d252bf98