### PR TITLE
Fix DMCA service endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -164,4 +164,5 @@ PUBLIC_HOST=https://suzookaizokuhunter.com
 # Bing Image Search
 ########################################
 BING_API_KEY=your-bing-api-key
-BING_API_ENDPOINT=https://<your-resource>.cognitiveservices.azure.com
+# Use your Cognitive Services endpoint or the general Bing endpoint
+BING_API_ENDPOINT=https://api.bing.microsoft.com

--- a/express/services/dmcaService.js
+++ b/express/services/dmcaService.js
@@ -13,40 +13,12 @@ if (isDmcaEnabled) {
   logger.warn('[DMCA Service] Service is DISABLED due to missing DMCA_API_EMAIL or DMCA_API_PASSWORD environment variables.');
 }
 
-const DMCA_API_BASE = process.env.DMCA_API_URL || 'https://api.dmca.com';
+let DMCA_API_ENDPOINT = process.env.DMCA_API_URL ||
+  'https://www.dmca.com/rest/takedowns/send';
 
-/**
- * Authenticate with DMCA API and return a token
- * @returns {Promise<string>}
- */
-async function login() {
-  const loginData = { email: DMCA_EMAIL, password: DMCA_PASSWORD };
-  const response = await axios.post(`${DMCA_API_BASE}/login`, loginData, {
-    headers: { 'Content-Type': 'application/json' },
-  });
-
-  let token = response.data;
-  // API may wrap token in quotes or return JSON
-  if (typeof token === 'object' && token.Token) {
-    token = token.Token;
-  }
-  return typeof token === 'string' ? token.replace(/"/g, '') : '';
-}
-
-/**
- * Call DMCA createCase API with provided token
- * @param {string} token
- * @param {object} caseData
- * @returns {Promise<object>}
- */
-async function createCase(token, caseData) {
-  const response = await axios.post(`${DMCA_API_BASE}/createCase`, caseData, {
-    headers: {
-      'Content-Type': 'application/json',
-      Token: token,
-    },
-  });
-  return response.data;
+// Allow using a base URL without the `/rest/takedowns/send` path for brevity
+if (!DMCA_API_ENDPOINT.includes('/rest/')) {
+  DMCA_API_ENDPOINT = `${DMCA_API_ENDPOINT.replace(/\/+$/, '')}/rest/takedowns/send`;
 }
 
 /**
@@ -71,27 +43,25 @@ async function sendTakedownRequest(takedownDetails) {
   }
 
   try {
-    logger.info(`[DMCA Service] Logging in to DMCA API for takedown of: ${infringingUrl}`);
-    const token = await login();
-    if (!token) throw new Error('Failed to obtain DMCA API token');
+    logger.info(`[DMCA Service] Sending takedown notice for: ${infringingUrl}`);
 
-    const caseData = {
-      Subject: 'Automated Takedown Request',
-      Description: description || 'Automated takedown request',
-      CopiedFromURL: originalUrl,
-      InfringingURL: infringingUrl,
-    };
+    const params = new URLSearchParams();
+    params.append('email', DMCA_EMAIL);
+    params.append('password', DMCA_PASSWORD);
+    params.append('infringingURL', infringingUrl);
+    params.append('originalURL', originalUrl);
+    if (description) params.append('description', description);
 
-    const response = await createCase(token, caseData);
+    const response = await axios.post(DMCA_API_ENDPOINT, params);
 
-    if (response && (response.status === 'success' || response.caseID)) {
-      logger.info(`[DMCA Service] Takedown request successful for ${infringingUrl}.`);
-      return { success: true, message: 'Case created', data: response };
+    if (response.data && response.data.status === 'success') {
+      logger.info(`[DMCA Service] Takedown request successful for ${infringingUrl}. Response: ${response.data.message}`);
+      return { success: true, message: response.data.message, data: response.data };
     }
 
-    const errorMsg = response && response.message ? response.message : 'Unknown error from DMCA API';
+    const errorMsg = response.data ? response.data.message : 'Unknown error from DMCA API';
     logger.error(`[DMCA Service] Takedown request failed: ${errorMsg}`);
-    return { success: false, message: errorMsg, data: response };
+    return { success: false, message: errorMsg, data: response.data };
   } catch (error) {
     const errorMsg = error.response ? JSON.stringify(error.response.data) : error.message;
     logger.error(`[DMCA Service] An exception occurred during takedown request: ${errorMsg}`);


### PR DESCRIPTION
## Summary
- fix DMCA takedown service to use original `/rest/takedowns/send` endpoint
- update example env file with Bing fallback endpoint

## Testing
- `pnpm test` *(fails: RabbitMQ channel not available)*

------
https://chatgpt.com/codex/tasks/task_e_68663eddc87c83249ae715ebc76d0e2a