### PR TITLE
Fix registration failing with 405

### DIFF
--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -95,7 +95,7 @@ export default function Login() {
         ? { email: identifier.trim().toLowerCase(), password }
         : { username: identifier.trim(), password };
 
-      const resp = await fetch('/auth/login', {
+      const resp = await fetch('/api/auth/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -135,7 +135,7 @@ export default function Register() {
     }
 
     try {
-      const resp = await fetch('/auth/register', {
+      const resp = await fetch('/api/auth/register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(form)


### PR DESCRIPTION
## Summary
- update client-side auth URLs to include `/api` prefix

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68664f00374083249bda2d84dad6beff