### PR TITLE
Implement plan and quota management

### DIFF
--- a/express/controllers/authController.js
+++ b/express/controllers/authController.js
@@ -84,7 +84,12 @@ async function register(req, res) {
       IG, FB, YouTube, TikTok,
       Shopee, Ruten, Yahoo, Amazon, Taobao, eBay,
       serialNumber,
-      role: finalRole
+      role: finalRole,
+      plan: 'free_trial',
+      status: 'active',
+      image_upload_limit: 10,
+      scan_limit_monthly: 20,
+      scan_usage_reset_at: new Date(new Date().setMonth(new Date().getMonth() + 1)),
     });
 
     // [I] 同步寫入區塊鏈 (非阻塞式)

--- a/express/middleware/quotaCheck.js
+++ b/express/middleware/quotaCheck.js
@@ -1,0 +1,28 @@
+const { User } = require('../models');
+
+const checkQuota = (checkType) => async (req, res, next) => {
+    const userId = req.user.id;
+    const user = await User.findByPk(userId);
+
+    if (!user) {
+        return res.status(404).json({ error: 'User not found.' });
+    }
+
+    if (checkType === 'upload') {
+        if (user.image_upload_usage >= user.image_upload_limit) {
+            return res.status(403).json({ error: '圖片上傳數量已達上限。請升級您的方案。' });
+        }
+    } else if (checkType === 'scan') {
+        if (user.scan_usage_reset_at && new Date() > new Date(user.scan_usage_reset_at)) {
+            user.scan_usage_monthly = 0;
+            user.scan_usage_reset_at = new Date(new Date().setMonth(new Date().getMonth() + 1));
+            await user.save();
+        }
+        if (user.scan_usage_monthly >= user.scan_limit_monthly) {
+            return res.status(403).json({ error: '本月侵權偵測次數已達上限。請升級您的方案。' });
+        }
+    }
+    next();
+};
+
+module.exports = checkQuota;

--- a/express/migrations/20250703105104-add-plan-and-quota-to-users.js
+++ b/express/migrations/20250703105104-add-plan-and-quota-to-users.js
@@ -1,0 +1,51 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('users', 'plan', {
+      type: Sequelize.STRING,
+      allowNull: false,
+      defaultValue: 'free_trial',
+    });
+    await queryInterface.addColumn('users', 'status', {
+      type: Sequelize.STRING,
+      allowNull: false,
+      defaultValue: 'active',
+    });
+    await queryInterface.addColumn('users', 'image_upload_limit', {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      defaultValue: 10,
+    });
+    await queryInterface.addColumn('users', 'scan_limit_monthly', {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      defaultValue: 20,
+    });
+    await queryInterface.addColumn('users', 'image_upload_usage', {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      defaultValue: 0,
+    });
+    await queryInterface.addColumn('users', 'scan_usage_monthly', {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      defaultValue: 0,
+    });
+    await queryInterface.addColumn('users', 'scan_usage_reset_at', {
+      type: Sequelize.DATE,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('users', 'scan_usage_reset_at');
+    await queryInterface.removeColumn('users', 'scan_usage_monthly');
+    await queryInterface.removeColumn('users', 'image_upload_usage');
+    await queryInterface.removeColumn('users', 'scan_limit_monthly');
+    await queryInterface.removeColumn('users', 'image_upload_limit');
+    await queryInterface.removeColumn('users', 'status');
+    await queryInterface.removeColumn('users', 'plan');
+  }
+};

--- a/express/models/User.js
+++ b/express/models/User.js
@@ -53,7 +53,13 @@ module.exports = (sequelize, DataTypes) => {
     birthDate: { type: DataTypes.STRING, allowNull: true },
     phone: { type: DataTypes.STRING, allowNull: true },
     address: { type: DataTypes.STRING, allowNull: true },
-    plan: { type: DataTypes.STRING, allowNull: false, defaultValue: 'freeTrial' },
+    plan: { type: DataTypes.STRING, allowNull: false, defaultValue: 'free_trial' },
+    status: { type: DataTypes.STRING, allowNull: false, defaultValue: 'active' },
+    image_upload_limit: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 10 },
+    scan_limit_monthly: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 20 },
+    image_upload_usage: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+    scan_usage_monthly: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+    scan_usage_reset_at: { type: DataTypes.DATE, allowNull: true },
     uploadVideos: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
     uploadImages: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 }
   }, {


### PR DESCRIPTION
## Summary
- add migration for plan and quota columns on users table
- extend `User` model with plan/quota fields
- preset plan defaults when creating users
- create reusable quota check middleware
- integrate quota checks into protect routes
- allow admin to update plans and quotas

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68665ffb87c883248b67914fc6f2e647