### PR TITLE
Implement login redirect and protected dashboard

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,7 +3,7 @@
  * 維持您既有 Navbar/Banner/UI；追加 Protect Step1~4 完整路由
  * - 加強容器之霓虹漸層效果
  **************************************************************/
-import React from 'react';
+import React, { useContext } from 'react';
 import {
   BrowserRouter,
   Routes,
@@ -23,6 +23,8 @@ import Payment from './pages/Payment';
 import PaymentSuccess from './pages/PaymentSuccess';
 import DashboardPage from './pages/DashboardPage';
 import FileDetailPage from './pages/FileDetailPage';
+import ProtectedRoute from './components/ProtectedRoute';
+import { AuthContext } from './AuthContext';
 
 // Protect (4-steps)
 import ProtectStep1 from './pages/ProtectStep1';
@@ -36,7 +38,7 @@ import AdminDashboard from './pages/AdminDashboard';
 import AdminUsersPage from './pages/AdminUsersPage';
 
 function RootLayout() {
-  const token = localStorage.getItem('token') || '';
+  const { token, logout } = useContext(AuthContext);
   let userRole = '';
   if (token) {
     try {
@@ -51,7 +53,7 @@ function RootLayout() {
   const showBanner = location.pathname === '/';
 
   const handleLogout = () => {
-    localStorage.clear();
+    logout();
     window.location.href = '/';
   };
 
@@ -82,6 +84,9 @@ function RootLayout() {
               <Link to="/register" style={styles.navLink}>Register</Link>
               <Link to="/login" style={styles.navLink}>Login</Link>
             </>
+          )}
+          {token && (
+            <Link to="/dashboard" style={styles.navLink}>Dashboard</Link>
           )}
           {userRole === 'admin' ? (
             <Link to="/admin/dashboard" style={styles.navLink}>Admin</Link>
@@ -147,8 +152,10 @@ export default function App() {
           <Route path="contact" element={<ContactPage />} />
           <Route path="login" element={<LoginPage />} />
          <Route path="register" element={<RegisterPage />} />
-          <Route path="dashboard" element={<DashboardPage />} />
-          <Route path="file/:fileId" element={<FileDetailPage />} />
+          <Route element={<ProtectedRoute />}>
+            <Route path="dashboard" element={<DashboardPage />} />
+            <Route path="file/:fileId" element={<FileDetailPage />} />
+          </Route>
 
           {/* Protect: Step1~4 */}
           <Route path="protect">

--- a/frontend/src/AuthContext.jsx
+++ b/frontend/src/AuthContext.jsx
@@ -1,0 +1,35 @@
+import React, { createContext, useState, useEffect } from 'react';
+
+export const AuthContext = createContext(null);
+
+export function AuthProvider({ children }) {
+  const [token, setToken] = useState(localStorage.getItem('authToken') || null);
+
+  const login = (newToken) => {
+    localStorage.setItem('authToken', newToken);
+    localStorage.setItem('token', newToken);
+    setToken(newToken);
+  };
+
+  const logout = () => {
+    localStorage.removeItem('authToken');
+    localStorage.removeItem('token');
+    setToken(null);
+  };
+
+  useEffect(() => {
+    const stored = localStorage.getItem('authToken');
+    if (stored && !token) {
+      setToken(stored);
+    }
+  }, [token]);
+
+  const value = {
+    token,
+    isAuthenticated: !!token,
+    login,
+    logout,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+
+const ProtectedRoute = () => {
+  const isAuthenticated = !!localStorage.getItem('authToken');
+  return isAuthenticated ? <Outlet /> : <Navigate to="/login" replace />;
+};
+
+export default ProtectedRoute;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import { installXhrOpenValidation } from './setupXhrValidation';
+import { AuthProvider } from './AuthContext';
 
 // Ensure any XHR usage in our app only targets well-formed URLs
 // to avoid jsdom errors like "The string did not match the expected pattern".
@@ -9,6 +10,8 @@ installXhrOpenValidation();
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </React.StrictMode>
 );

--- a/frontend/src/pages/DashboardPage.js
+++ b/frontend/src/pages/DashboardPage.js
@@ -1,6 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
+import { AuthContext } from '../AuthContext';
 
-function DashboardPage({ token }) {
+function DashboardPage() {
+  const { token } = useContext(AuthContext);
   const [userData, setUserData] = useState(null);
   const [error, setError] = useState('');
 

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,6 +1,7 @@
 // frontend/src/pages/Login.jsx
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
+import { AuthContext } from '../AuthContext';
 import styled from 'styled-components';
 
 const PageWrapper = styled.div`
@@ -81,6 +82,7 @@ const SwitchPrompt = styled.p`
 
 export default function Login() {
   const navigate = useNavigate();
+  const { login } = useContext(AuthContext);
   const [identifier, setIdentifier] = useState('');
   const [password, setPassword] = useState('');
   const [errorMsg, setErrorMsg] = useState('');
@@ -108,10 +110,10 @@ export default function Login() {
       }
 
       if (data.token) {
-        localStorage.setItem('token', data.token);
+        login(data.token);
       }
       alert(data.message || '登入成功');
-      navigate('/');
+      navigate('/dashboard');
     } catch (err) {
       console.error(err);
       setErrorMsg('伺服器錯誤');


### PR DESCRIPTION
## Summary
- redirect to dashboard after successful login
- enforce authenticated access with a `ProtectedRoute` component
- add global `AuthProvider` for auth state
- update navbar and routes to use new protected logic

## Testing
- `pnpm test` *(fails: suzoo-express tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_686734db007c8324b687a6734cd1443d