### PR TITLE
Fix duplicate seed errors in express service

### DIFF
--- a/express/seeders/20250704104000-seed-subscriptionplans.js
+++ b/express/seeders/20250704104000-seed-subscriptionplans.js
@@ -6,7 +6,12 @@ module.exports = {
       { plan_code: 'pro', name: 'PRO', monthly_price: 30, annual_price: 300, video_limit: null, image_limit: null, image_upload_limit: null, scan_limit_monthly: null, dmca_free: 10, dmca_takedown_limit_monthly: 10, scan_frequency_in_hours: 24, scan_frequency: 'daily', has_legal_consultation: true, createdAt: new Date(), updatedAt: new Date() },
       { plan_code: 'enterprise', name: 'ENTERPRISE', monthly_price: 100, annual_price: 1000, video_limit: null, image_limit: null, image_upload_limit: null, scan_limit_monthly: null, dmca_free: null, dmca_takedown_limit_monthly: null, scan_frequency_in_hours: 24, scan_frequency: 'realtime', has_legal_consultation: true, createdAt: new Date(), updatedAt: new Date() },
       { plan_code: 'pay_per_feature', name: 'PAY_PER_FEATURE', monthly_price: 0, annual_price: 0, video_limit: null, image_limit: null, image_upload_limit: null, scan_limit_monthly: null, dmca_free: 0, dmca_takedown_limit_monthly: 0, scan_frequency_in_hours: 24, scan_frequency: '24h', has_legal_consultation: false, createdAt: new Date(), updatedAt: new Date() }
-    ]);
+    ], {
+      // Skip inserting a record if a plan with the same `plan_code`
+      // already exists. The container runs seeders on every start,
+      // so we need idempotent inserts.
+      ignoreDuplicates: true
+    });
   },
   async down (queryInterface) {
     await queryInterface.bulkDelete('SubscriptionPlans', null, {});

--- a/express/seeders/20250705031821-initial-subscription-plans.js
+++ b/express/seeders/20250705031821-initial-subscription-plans.js
@@ -58,9 +58,13 @@ module.exports = {
     ];
 
     // 使用 bulkInsert 寫入資料，並設定如果 plan_code 已存在則忽略，避免重複寫入
+    // PostgreSQL in Sequelize 6.x does not fully support the
+    // `updateOnDuplicate` option for bulkInsert. Using it results in
+    // runtime errors such as "Cannot read properties of undefined".
+    // Instead, rely on `ignoreDuplicates` to skip records that already
+    // exist based on the unique `plan_code` constraint.
     await queryInterface.bulkInsert('SubscriptionPlans', plans, {
-      ignoreDuplicates: true, // 關鍵設定：如果主鍵或唯一鍵衝突，則不執行插入
-      updateOnDuplicate: ['name'] // Or pick a field that can be updated if needed
+      ignoreDuplicates: true
     });
   },
 


### PR DESCRIPTION
## Summary
- make subscription plan seeders idempotent
- remove updateOnDuplicate option incompatible with PostgreSQL

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68689d46b89c8324a802b249ca392c65