### PR TITLE
Fix missing user quota fields

### DIFF
--- a/express/migrations/20250707123000-add-plan-and-quota-fields-to-users.js
+++ b/express/migrations/20250707123000-add-plan-and-quota-fields-to-users.js
@@ -1,0 +1,51 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    // 使用 Promise.all 來並行新增所有欄位
+    await Promise.all([
+      queryInterface.addColumn('users', 'status', {
+        type: Sequelize.STRING,
+        allowNull: false,
+        defaultValue: 'active'
+      }),
+      queryInterface.addColumn('users', 'image_upload_limit', {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        defaultValue: 5
+      }),
+      queryInterface.addColumn('users', 'scan_limit_monthly', {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        defaultValue: 10
+      }),
+      queryInterface.addColumn('users', 'dmca_takedown_limit_monthly', {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        defaultValue: 0
+      }),
+      queryInterface.addColumn('users', 'scan_usage_monthly', {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        defaultValue: 0
+      }),
+      queryInterface.addColumn('users', 'scan_usage_reset_at', {
+        type: Sequelize.DATE,
+        allowNull: true
+      })
+    ]);
+  },
+
+  async down (queryInterface, Sequelize) {
+    // 定義 "down" 操作，以便未來可以復原這些變更
+    await Promise.all([
+      queryInterface.removeColumn('users', 'status'),
+      queryInterface.removeColumn('users', 'image_upload_limit'),
+      queryInterface.removeColumn('users', 'scan_limit_monthly'),
+      queryInterface.removeColumn('users', 'dmca_takedown_limit_monthly'),
+      queryInterface.removeColumn('users', 'scan_usage_monthly'),
+      queryInterface.removeColumn('users', 'scan_usage_reset_at')
+    ]);
+  }
+};

--- a/express/models/User.js
+++ b/express/models/User.js
@@ -32,8 +32,8 @@ module.exports = (sequelize, DataTypes) => {
     TikTok: { type: DataTypes.STRING },
     
     // 額度欄位 (由 Admin 或 Plan 指派時更新)
-    image_upload_limit: { type: DataTypes.INTEGER, defaultValue: 0 },
-    scan_limit_monthly: { type: DataTypes.INTEGER, defaultValue: 0 },
+    image_upload_limit: { type: DataTypes.INTEGER, defaultValue: 5 },
+    scan_limit_monthly: { type: DataTypes.INTEGER, defaultValue: 10 },
     dmca_takedown_limit_monthly: { type: DataTypes.INTEGER, defaultValue: 0 },
 
     // 用量追蹤 (可選，但建議保留以提高查詢效能)


### PR DESCRIPTION
## Summary
- add migration to include quota columns in users table
- update User model defaults for quotas

## Testing
- `npm test --silent` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68694b2776ac8324a2eda1897de7b0bb