### PR TITLE
Fix RabbitMQ startup call

### DIFF
--- a/express/server.js
+++ b/express/server.js
@@ -80,7 +80,7 @@ async function startServer() {
         logger.info('[Startup] Step 2: Database schema managed by migrations.');
 
         logger.info('[Startup] Step 3: Initializing RabbitMQ connection...');
-        await queueService.init();
+        await queueService.connect();
         logger.info('[Startup] Step 3: RabbitMQ connection successful.');
 
         logger.info('[Startup] Step 4: Setting up default admin user...');


### PR DESCRIPTION
## Summary
- correct call to queueService.connect in `express/server.js`

## Testing
- `npm test` *(fails: command not found or dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a72de4e888324a67a680f7aaa8106