### PR TITLE
Upgrade dashboard callbacks

### DIFF
--- a/frontend/src/components/FileCard.jsx
+++ b/frontend/src/components/FileCard.jsx
@@ -95,13 +95,17 @@ const ScanButton = styled(ActionButton)`
 `;
 
 export default function FileCard({ file, onScan }) {
+  // 從檔案的掃描紀錄中，找出最新的那一筆
   const latestScan = file.scans && file.scans.length > 0 ? file.scans[0] : null;
+  // 決定要顯示的狀態文字
   const scanStatus = latestScan?.status || 'Not Scanned';
+  // 計算已發現的侵權連結數
   const infringementCount = latestScan?.result?.scan?.totalMatches || 0;
 
   const handleScanClick = () => {
-      if (scanStatus === 'pending' || scanStatus === 'processing') return;
-      onScan(file.fileId);
+    // 如果正在掃描中，則不執行任何操作
+    if (scanStatus === 'pending' || scanStatus === 'processing') return;
+    onScan(file.fileId);
   };
 
   return (
@@ -109,15 +113,18 @@ export default function FileCard({ file, onScan }) {
       <Thumbnail src={file.thumbnailUrl} />
       <CardContent>
         <FileName title={file.fileName}>{file.fileName}</FileName>
-        <InfoText><span>SHA256:</span> {file.fingerprint}</InfoText>
+        <InfoText title={file.fingerprint}><span>SHA256:</span> {file.fingerprint}</InfoText>
+        <InfoText title={file.ipfsHash}><span>IPFS:</span> {file.ipfsHash}</InfoText>
         <InfoText>
           <span>狀態:</span>
-          {scanStatus === 'completed' ? ` 掃描完成 - 發現 ${infringementCount} 個潛在侵權` : ` ${scanStatus}`}
+          {/* 根據狀態顯示不同文字 */}
+          {scanStatus === 'completed' ? ` 掃描完成 - 發現 ${infringementCount} 個潛在侵權` : scanStatus}
         </InfoText>
         <Actions>
           <ScanButton onClick={handleScanClick} disabled={scanStatus === 'pending' || scanStatus === 'processing'}>
             {scanStatus === 'pending' || scanStatus === 'processing' ? '偵測中...' : '發動侵權偵測'}
           </ScanButton>
+          {/* 將詳情按鈕改為真實的連結 */}
           <ActionButton as={Link} to={`/file/${file.fileId}`} style={{textDecoration: 'none', textAlign: 'center', lineHeight: '1.5'}}>
             詳情與申訴
           </ActionButton>


### PR DESCRIPTION
## Summary
- enhance backend dashboard API with thumbnails and hash info
- add functional FileCard component with scan actions
- refresh dashboard after upload or scan using new callbacks
- call real APIs from BulkUploader

## Testing
- `npm test` *(fails: turbo not found)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b50efdb248324923cdfaf00c950a4