### PR TITLE
Fix admin login by allowing username

### DIFF
--- a/express/routes/admin.js
+++ b/express/routes/admin.js
@@ -19,7 +19,11 @@ router.post('/login', async (req, res) => {
 
         const user = await User.findOne({
             where: {
-                [Op.or]: [{ email: username }, { phone: username }],
+                [Op.or]: [
+                    { email: username },
+                    { phone: username },
+                    { username: username }
+                ],
                 role: 'admin' // 直接在查詢時就限定必須是 admin
             }
         });


### PR DESCRIPTION
## Summary
- allow admins to log in using their username as well as email or phone

## Testing
- `npm test` *(fails: `turbo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b91a156c083248242a2173824e922