### PR TITLE
Improve dashboard API robustness

### DIFF
--- a/express/models/File.js
+++ b/express/models/File.js
@@ -38,6 +38,12 @@ module.exports = (sequelize, DataTypes) => {
     },
     ipfs_hash: DataTypes.STRING,
     tx_hash: DataTypes.STRING,
+
+    // 用於前端顯示縮圖的路徑
+    thumbnail_path: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
     
     // 狀態與結果
     status: DataTypes.STRING,


### PR DESCRIPTION
## Summary
- add `thumbnail_path` to File model
- fix alias in Scan.count within dashboard route
- fallback to request host when `PUBLIC_HOST` isn't set
- log error stack for dashboard failures

## Testing
- `npx --yes turbo run test` *(fails: Could not resolve workspaces)*

------
https://chatgpt.com/codex/tasks/task_e_686b997a7d508324a7359a9c9246d2b8