### PR TITLE
Fix uploads proxy and sequential IPFS

### DIFF
--- a/frontend/nginx/default.conf
+++ b/frontend/nginx/default.conf
@@ -1,13 +1,39 @@
-# /frontend/nginx/default.conf (最終生產版 v3.1)
+# /frontend/nginx/default.conf (最終路由版)
 server {
     listen 80;
     server_name _;
     root /usr/share/nginx/html;
     index index.html index.htm;
+
     client_max_body_size 100M;
 
-    # 將 /auth, /admin, /api 開頭的所有請求都轉發給 Express 後端
-    location ~ ^/(auth|admin|api)/ {
+    # [新增] 處理靜態檔案路徑，轉發給 Express
+    # 解決縮圖無法顯示的問題
+    location /uploads/ {
+        proxy_pass http://suzoo_express:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /auth/ {
+        proxy_pass http://suzoo_express:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /admin/ {
+        proxy_pass http://suzoo_express:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /api/ {
         proxy_pass http://suzoo_express:3000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
- configure Nginx to proxy `/uploads` to Express
- await IPFS hash before writing blockchain record

## Testing
- `npm run lint`
- `npm test` *(fails: cannot install sharp, missing credentials)*

------
https://chatgpt.com/codex/tasks/task_e_686bbcaf0cf48324b2a50483f5b7b94f