### PR TITLE
Fix missing tini in express Dockerfile

### DIFF
--- a/express/Dockerfile
+++ b/express/Dockerfile
@@ -6,6 +6,8 @@ FROM node:20-slim
 # [FIX] 安裝 Puppeteer 運行所需的所有系統函式庫
 RUN apt-get update \
     && apt-get install -y \
+    tini \
+    curl \
     ca-certificates \
     fonts-liberation \
     libasound2 \


### PR DESCRIPTION
## Summary
- install `tini` and `curl` so suzoo_express container starts correctly

## Testing
- `pnpm install`
- `pnpm test` *(fails: cannot find module `sharp-linux-x64.node`, Vision credentials missing)*

------
https://chatgpt.com/codex/tasks/task_e_686be3e619b083248ef1d3737189ef4c