### PR TITLE
Fix Puppeteer dependencies

### DIFF
--- a/express/Dockerfile
+++ b/express/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update \
     libasound2 \
     libatk-bridge2.0-0 \
     libatk1.0-0 \
+    libgobject-2.0-0 \
     libc6 \
     libcairo2 \
     libcups2 \


### PR DESCRIPTION
## Summary
- add missing libgobject-2.0-0 dependency for Puppeteer

## Testing
- `npm test` *(fails: turbo not found)*
- `pnpm test` *(fails: turbo not found)*
- `docker compose up -d --build --force-recreate` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bebda1ca4832491be239a26795258