### PR TITLE
Improve Express container startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,8 @@ services:
       npx sequelize-cli db:migrate --config /app/config/database.js && \
       npx sequelize-cli db:seed:all --config /app/config/database.js && \
       node server.js"
+    environment:
+      - PUPPETEER_SKIP_DOWNLOAD=true
     ports:
       - "3000:3000"
     env_file:
@@ -101,6 +103,8 @@ services:
     command: sh -c "npm install && node worker.js"
     env_file:
       - .env
+    environment:
+      - PUPPETEER_SKIP_DOWNLOAD=true
     volumes:
       - ./express:/app
       - /app/node_modules

--- a/express/server.js
+++ b/express/server.js
@@ -55,7 +55,10 @@ async function startServer() {
     // ... (保留您原有的 startServer 函式內容)
     try {
         logger.info('[Startup] Step 1: Initializing Database connection...');
-        await db.sequelize.authenticate();
+        await db.connectToDatabase(
+            process.env.DB_CONNECT_RETRIES || 10,
+            process.env.DB_CONNECT_RETRY_DELAY || 5000
+        );
         logger.info('[Startup] Step 1: Database connection successful.');
 
         // ...其他啟動步驟...
@@ -65,6 +68,7 @@ async function startServer() {
         });
     } catch (error) {
         logger.error('[Startup] Failed to start Express server:', error);
+        console.error(error);
         process.exit(1);
     }
 }

--- a/express/worker.js
+++ b/express/worker.js
@@ -66,7 +66,10 @@ async function processScanTask(task) {
 async function startWorker() {
     try {
         logger.info('[Worker] Starting up...');
-        await db.sequelize.authenticate();
+        await db.connectToDatabase(
+            process.env.DB_CONNECT_RETRIES || 10,
+            process.env.DB_CONNECT_RETRY_DELAY || 5000
+        );
         logger.info('[Worker] Database connection established.');
         
         await queueService.connect();
@@ -78,6 +81,7 @@ async function startWorker() {
         });
     } catch (error) {
         logger.error('[Worker] Failed to start:', error);
+        console.error(error);
         process.exit(1);
     }
 }


### PR DESCRIPTION
## Summary
- ensure puppeteer skip download for Node services
- add DB retry logic and console error logs in express server and worker

## Testing
- `npx --no-install turbo run test` *(fails: missing packages due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686d3dbd08d88324aa6f4eab3aa8415c