### PR TITLE
Fix express startup and add error handling

### DIFF
--- a/express/server.js
+++ b/express/server.js
@@ -8,8 +8,16 @@ const logger = require('./utils/logger');
 const { initSocket } = require('./socket');
 const db = require('./models');
 
+// Global error handlers to prevent silent exits
+process.on('uncaughtException', err => {
+    logger.error('[Uncaught Exception]', err);
+});
+process.on('unhandledRejection', err => {
+    logger.error('[Unhandled Rejection]', err);
+});
+
 // --- Routers ---
-const authRouter = require('./routes/auth');
+const authRouter = require('./routes/authRoutes');
 const protectRouter = require('./routes/protect');
 // ... (保留您其他的 router require) ...
 const filesRouter = require('./routes/files');

--- a/express/worker.js
+++ b/express/worker.js
@@ -9,6 +9,14 @@ const { getIO, initSocket } = require('./socket');
 const express = require('express');
 const http = require('http');
 
+// Prevent worker from exiting silently on unexpected errors
+process.on('uncaughtException', err => {
+    logger.error('[Worker Uncaught Exception]', err);
+});
+process.on('unhandledRejection', err => {
+    logger.error('[Worker Unhandled Rejection]', err);
+});
+
 const app = express();
 const server = http.createServer(app);
 initSocket(server);


### PR DESCRIPTION
## Summary
- fix incorrect auth router path in `server.js`
- add global exception handlers in express server and worker

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in express *(fails: missing credentials)*

------
https://chatgpt.com/codex/tasks/task_e_686d47770f508324bfdaf726b2851060