### PR TITLE
Fix IPFS logging and local host defaults

### DIFF
--- a/express/services/imageProcessor.js
+++ b/express/services/imageProcessor.js
@@ -2,7 +2,8 @@ const fs = require('fs');
 const path = require('path');
 const { convertAndUpload: baseConvertAndUpload } = require('../utils/convertAndUpload');
 
-const PUBLIC_HOST = process.env.PUBLIC_HOST || 'https://suzookaizokuhunter.com';
+// Default to localhost for development if PUBLIC_HOST not specified
+const PUBLIC_HOST = process.env.PUBLIC_HOST || 'http://localhost:3000';
 // Resolve to project-level uploads directory
 const UPLOAD_BASE_DIR = path.resolve(__dirname, '..', '..', 'uploads');
 const PUBLIC_IMAGES_DIR = path.join(UPLOAD_BASE_DIR, 'publicImages');

--- a/express/services/ipfsService.js
+++ b/express/services/ipfsService.js
@@ -35,8 +35,9 @@ class IpfsService {
     try {
       logger.info(`[ipfsService.saveFile] buffer length=${buffer.length}`);
       const { cid } = await this.client.add(buffer);
-      logger.info('[ipfsService.saveFile] => CID=', cid.toString());
-      return cid.toString();
+      const cidStr = cid.toString();
+      logger.info(`[ipfsService.saveFile] => CID=${cidStr}`);
+      return cidStr;
     } catch (error) {
       logger.error('[ipfsService.saveFile] Error saving file to IPFS:', error);
       return null;

--- a/express/utils/convertAndUpload.js
+++ b/express/utils/convertAndUpload.js
@@ -22,7 +22,8 @@ const sharp = require('sharp');
  * - PUBLIC_HOST: 自訂主機名，如 https://suzookaizokuhunter.com
  */
 const USE_S3_UPLOAD = (process.env.USE_S3_UPLOAD === 'true');
-const PUBLIC_HOST = process.env.PUBLIC_HOST || 'https://suzookaizokuhunter.com';
+// Default to localhost for development if PUBLIC_HOST not specified
+const PUBLIC_HOST = process.env.PUBLIC_HOST || 'http://localhost:3000';
 
 // 本地模式預設的 uploads/publicImages 路徑
 const UPLOAD_BASE_DIR = path.resolve(__dirname, '..', '..', 'uploads');


### PR DESCRIPTION
## Summary
- improve IPFS CID logging to ensure CID string shows in logs
- default PUBLIC_HOST to `http://localhost:3000` when not provided

## Testing
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d57d3c9688324abe25997c34aecb6