### PR TITLE
Improve IPFS save and thumbnail URL handling

### DIFF
--- a/express/routes/files.js
+++ b/express/routes/files.js
@@ -26,7 +26,8 @@ router.get('/:id', auth, async (req, res) => {
 
         const fileData = file.toJSON();
         if (fileData.thumbnail_path) {
-            fileData.thumbnailUrl = `${process.env.PUBLIC_HOST}${file.thumbnail_path}`;
+            const baseUrl = process.env.PUBLIC_HOST || req.protocol + '://' + req.get('host');
+            fileData.thumbnailUrl = `${baseUrl}${file.thumbnail_path}`;
         }
 
         res.json(fileData);

--- a/express/services/ipfsService.js
+++ b/express/services/ipfsService.js
@@ -34,8 +34,19 @@ class IpfsService {
     }
     try {
       logger.info(`[ipfsService.saveFile] buffer length=${buffer.length}`);
-      const { cid } = await this.client.add(buffer);
-      const cidStr = cid.toString();
+      const result = await this.client.add(buffer);
+      logger.debug(`[ipfsService.saveFile] raw add result: ${JSON.stringify(result)}`);
+      let cidStr = '';
+      if (result.cid) {
+        cidStr = result.cid.toString ? result.cid.toString() : String(result.cid);
+      } else if (result.Hash) {
+        cidStr = result.Hash;
+      } else if (result.path) {
+        cidStr = result.path;
+      }
+      if (!cidStr) {
+        throw new Error('IPFS add returned empty CID');
+      }
       logger.info(`[ipfsService.saveFile] => CID=${cidStr}`);
       return cidStr;
     } catch (error) {


### PR DESCRIPTION
## Summary
- ensure IPFS saveFile handles various response formats
- fix files route to build thumbnail URL using request host when PUBLIC_HOST is unset

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d60ce68008324b9a8b2e610111a7d