### PR TITLE
Fix upload path resolution for thumbnails

### DIFF
--- a/express/routes/protect.js
+++ b/express/routes/protect.js
@@ -16,7 +16,7 @@ const queueService = require('../services/queue.service');
 const router = express.Router();
 // [FIX] ensure uploads path resolves to '/app/uploads' inside container
 // Use project-level uploads directory mounted at /app/uploads
-const UPLOAD_BASE_DIR = path.resolve(__dirname, '..', '..', 'uploads');
+const UPLOAD_BASE_DIR = path.resolve(__dirname, '..', 'uploads');
 const TEMP_DIR = path.join(UPLOAD_BASE_DIR, 'temp');
 const THUMBNAIL_DIR = path.join(UPLOAD_BASE_DIR, 'thumbnails');
 

--- a/express/routes/uploadRoutes.js
+++ b/express/routes/uploadRoutes.js
@@ -40,7 +40,7 @@ router.post(
       //    假設此檔案位於: express/routes/uploadRoutes.js
       //    跳兩層回到專案根，再進到 uploads/
       //    => /app/uploads
-      const uploadsDir = path.resolve(__dirname, '..', '..', 'uploads');
+      const uploadsDir = path.resolve(__dirname, '..', 'uploads');
       if (!fs.existsSync(uploadsDir)) {
         fs.mkdirSync(uploadsDir, { recursive: true });
       }

--- a/express/services/imageProcessor.js
+++ b/express/services/imageProcessor.js
@@ -5,7 +5,7 @@ const { convertAndUpload: baseConvertAndUpload } = require('../utils/convertAndU
 // Default to localhost for development if PUBLIC_HOST not specified
 const PUBLIC_HOST = process.env.PUBLIC_HOST || 'http://localhost:3000';
 // Resolve to project-level uploads directory
-const UPLOAD_BASE_DIR = path.resolve(__dirname, '..', '..', 'uploads');
+const UPLOAD_BASE_DIR = path.resolve(__dirname, '..', 'uploads');
 const PUBLIC_IMAGES_DIR = path.join(UPLOAD_BASE_DIR, 'publicImages');
 
 function createPublicImageLink(fileId) {

--- a/express/services/pdf.service.js
+++ b/express/services/pdf.service.js
@@ -8,7 +8,7 @@ const { User, File } = require('../models');
 // --- 目錄設定 ---
 // ensure path is resolved relative to /app
 // Resolve to project-level uploads directory
-const UPLOAD_BASE_DIR = path.resolve(__dirname, '..', '..', 'uploads');
+const UPLOAD_BASE_DIR = path.resolve(__dirname, '..', 'uploads');
 const CERT_DIR = path.join(UPLOAD_BASE_DIR, 'certificates');
 
 // --- 啟動時檢查並建立目錄 ---

--- a/express/utils/convertAndUpload.js
+++ b/express/utils/convertAndUpload.js
@@ -26,7 +26,7 @@ const USE_S3_UPLOAD = (process.env.USE_S3_UPLOAD === 'true');
 const PUBLIC_HOST = process.env.PUBLIC_HOST || 'http://localhost:3000';
 
 // 本地模式預設的 uploads/publicImages 路徑
-const UPLOAD_BASE_DIR = path.resolve(__dirname, '..', '..', 'uploads');
+const UPLOAD_BASE_DIR = path.resolve(__dirname, '..', 'uploads');
 const PUBLIC_IMAGES_DIR = path.join(UPLOAD_BASE_DIR, 'publicImages');
 
 // 建立本地目錄（若不存在）

--- a/express/utils/extractFrames.js
+++ b/express/utils/extractFrames.js
@@ -12,7 +12,7 @@ const { execSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
-const UPLOAD_BASE_DIR = path.resolve(__dirname, '..', '..', 'uploads');
+const UPLOAD_BASE_DIR = path.resolve(__dirname, '..', 'uploads');
 
 /**
  * 將總秒數格式化為 HH:MM:SS.mmm 格式


### PR DESCRIPTION
## Summary
- point upload directories inside Express to `/app/uploads`

## Testing
- `npx turbo run test` *(fails: needs `turbo@2.5.4`)*

------
https://chatgpt.com/codex/tasks/task_e_686dd6c32ed083249cd2a28dff3e59b5