### PR TITLE
Fix jwt-decode imports

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,7 +1,7 @@
 // frontend/src/App.js (最終版)
 import React, { useContext, useEffect } from 'react';
 import { BrowserRouter, Routes, Route, Link, Outlet } from 'react-router-dom';
-import jwt_decode from 'jwt-decode';
+import { jwtDecode } from 'jwt-decode';
 import styled, { createGlobalStyle } from 'styled-components';
 import { AuthContext } from './AuthContext';
 import { setupResponseInterceptor } from './utils/apiClient';
@@ -114,7 +114,7 @@ function RootLayout() {
   let userRole = '';
   if (token) {
     try {
-      const decoded = jwt_decode(token);
+      const decoded = jwtDecode(token);
       userRole = decoded.role || '';
     } catch (e) {
       console.error('Invalid token decode', e);

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -1,7 +1,7 @@
 // frontend/src/components/ProtectedRoute.jsx (最終版)
 import React, { useContext } from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
-import jwt_decode from 'jwt-decode';
+import { jwtDecode } from 'jwt-decode';
 import { AuthContext } from '../AuthContext';
 
 /**
@@ -19,7 +19,7 @@ export default function ProtectedRoute({ allowedRoles = [] }) {
   }
 
   try {
-    const decoded = jwt_decode(token);
+    const decoded = jwtDecode(token);
     // 如果路由有權限限制，且使用者的角色不在允許清單內，則導向首頁
     if (allowedRoles.length > 0 && !allowedRoles.includes(decoded.role)) {
       return <Navigate to="/" replace />;


### PR DESCRIPTION
## Summary
- align `jwt-decode` usage with version 4 API

## Testing
- `npm test` *(fails: turbo not found)*
- `npm run build` *(fails: Cannot find module '@typescript-eslint/parser')*

------
https://chatgpt.com/codex/tasks/task_e_686e358018588324aaabb954774c3e94