### PR TITLE
Fix jwt-decode imports

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,7 +1,7 @@
 // frontend/src/App.js (最終版)
 import React, { useContext, useEffect } from 'react';
 import { BrowserRouter, Routes, Route, Link, Outlet } from 'react-router-dom';
-import { jwtDecode } from 'jwt-decode';
+import jwtDecode from 'jwt-decode';
 import styled, { createGlobalStyle } from 'styled-components';
 import { AuthContext } from './AuthContext';
 import { setupResponseInterceptor } from './utils/apiClient';

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -1,7 +1,7 @@
 // frontend/src/components/ProtectedRoute.jsx (最終版)
 import React, { useContext } from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
-import { jwtDecode } from 'jwt-decode';
+import jwtDecode from 'jwt-decode';
 import { AuthContext } from '../AuthContext';
 
 /**


### PR DESCRIPTION
## Summary
- adjust jwt-decode imports to use default export in `ProtectedRoute.jsx`
- adjust jwt-decode import in `App.js`

## Testing
- `pnpm run test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e495621a483248078a7765e6a295d