### PR TITLE
Fix frontend page imports and routes

### DIFF
--- a/frontend/src/MyRoutes.jsx
+++ b/frontend/src/MyRoutes.jsx
@@ -5,13 +5,13 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import App from './App';
 
 // 各子頁面
-import Home from './pages/Home';
-import Login from './pages/Login';
-import Register from './pages/Register';
+import HomePage from './pages/HomePage';
+import LoginPage from './pages/LoginPage';
+import RegisterPage from './pages/RegisterPage';
 import PricingPage from './pages/PricingPage';
 import PaymentPage from './pages/PaymentPage';
-import AdminDashboard from './pages/AdminDashboard';
-import ContactUsPage from './pages/ContactUsPage'; // ★ 新增
+import AdminDashboardPage from './pages/AdminDashboardPage';
+import ContactPage from './pages/ContactPage'; // ★ 新增
 
 export default function MyRoutes() {
   return (
@@ -20,19 +20,19 @@ export default function MyRoutes() {
         {/* 最外層路由：使用 <App /> 作為 Layout */}
         <Route path="/" element={<App />}>
           {/* index -> 根路徑顯示 Home */}
-          <Route index element={<Home />} />
+          <Route index element={<HomePage />} />
 
           {/* 已定義的子頁面： /login, /register, /pricing, /payment */}
-          <Route path="login" element={<Login />} />
-          <Route path="register" element={<Register />} />
+          <Route path="login" element={<LoginPage />} />
+          <Route path="register" element={<RegisterPage />} />
           <Route path="pricing" element={<PricingPage />} />
           <Route path="payment" element={<PaymentPage />} />
 
           {/* 新增 Contact Us 路由：/contact */}
-          <Route path="contact" element={<ContactUsPage />} />
+          <Route path="contact" element={<ContactPage />} />
 
           {/* 管理員頁面: /admin (若您想要 /admin/dashboard，也可以在此再做細分) */}
-          <Route path="admin" element={<AdminDashboard />} />
+          <Route path="admin" element={<AdminDashboardPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/frontend/src/pages/AdminLoginPage.jsx
+++ b/frontend/src/pages/AdminLoginPage.jsx
@@ -1,4 +1,4 @@
-// frontend/src/pages/AdminLogin.jsx (最終版)
+// frontend/src/pages/AdminLoginPage.jsx (最終版)
 import React, { useState, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AuthContext } from '../AuthContext';

--- a/frontend/src/pages/ContactPage.js
+++ b/frontend/src/pages/ContactPage.js
@@ -1,4 +1,4 @@
-// frontend/src/pages/ContactUsPage.js
+// frontend/src/pages/ContactPage.js
 import React, { useState } from 'react';
 
 export default function ContactUsPage() {

--- a/frontend/src/pages/HomePage.js
+++ b/frontend/src/pages/HomePage.js
@@ -1,4 +1,4 @@
-// frontend/src/pages/Home.js
+// frontend/src/pages/HomePage.js
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,4 +1,4 @@
-// frontend/src/pages/Login.jsx (最終版)
+// frontend/src/pages/LoginPage.jsx (最終版)
 import React, { useState, useContext } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { AuthContext } from '../AuthContext';

--- a/frontend/src/pages/NotFoundPage.jsx
+++ b/frontend/src/pages/NotFoundPage.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export default function NotFoundPage() {
+  return (
+    <div style={{ textAlign: 'center', padding: '3rem' }}>
+      <h1 style={{ fontSize: '2rem', marginBottom: '1rem' }}>404 - Page Not Found</h1>
+      <p style={{ marginBottom: '1.5rem' }}>The page you are looking for does not exist.</p>
+      <Link to="/" style={{ color: '#f97316' }}>Return Home</Link>
+    </div>
+  );
+}

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -1,4 +1,4 @@
-// frontend/src/pages/Register.jsx
+// frontend/src/pages/RegisterPage.jsx
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';


### PR DESCRIPTION
## Summary
- rename page components to match App.js
- update MyRoutes imports to new page paths
- add NotFoundPage component for 404s

## Testing
- `pnpm exec turbo run test` *(fails: sharp module missing)*
- `npm run build` in `frontend` *(fails: jwt-decode default export error)*

------
https://chatgpt.com/codex/tasks/task_e_686e5000547c832495ea3498e4401ee9