### PR TITLE
Fix nginx conf path in frontend Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -26,8 +26,8 @@ FROM nginx:alpine
 # 將 React build 產物放進 Nginx 預設靜態目錄
 COPY --from=builder /app/build /usr/share/nginx/html
 
-# 若要自訂 nginx conf（建議），請取消下一行註解並提供檔案
-COPY suzoo.conf /etc/nginx/conf.d/default.conf
+# 複製我們為生產環境準備的「黃金版」設定檔
+COPY nginx/default.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 


### PR DESCRIPTION
## Summary
- copy nginx production config instead of dev config in `frontend/Dockerfile`

## Testing
- `pnpm test` *(fails: `turbo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ea2ea33e483249f719f24fa38eb34