### PR TITLE
Fix PostgreSQL table name case

### DIFF
--- a/express/migrations/20250710150000-create-usage-record.js
+++ b/express/migrations/20250710150000-create-usage-record.js
@@ -13,7 +13,7 @@ module.exports = {
         type: Sequelize.INTEGER,
         allowNull: false,
         references: {
-          model: 'Users', // 確保與 User 表的表名一致
+          model: 'users', // 需與 users 表名稱一致
           key: 'id',
         },
         onUpdate: 'CASCADE',

--- a/express/migrations/20250711010000-create-scans.js
+++ b/express/migrations/20250711010000-create-scans.js
@@ -23,7 +23,7 @@ module.exports = {
         type: Sequelize.INTEGER,
         allowNull: false,
         references: {
-          model: 'Users', // 關聯到 Users 表
+          model: 'users', // 關聯到 users 表
           key: 'id',
         },
         onUpdate: 'CASCADE',

--- a/express/migrations/20250711200000-create-scans.js
+++ b/express/migrations/20250711200000-create-scans.js
@@ -23,7 +23,7 @@ module.exports = {
         type: Sequelize.INTEGER,
         allowNull: false,
         references: {
-          model: 'Users', // 關聯到 Users 表
+          model: 'users', // 關聯到 users 表
           key: 'id',
         },
         onUpdate: 'CASCADE',

--- a/express/migrations/20250711210000-add-userid-to-scans.js
+++ b/express/migrations/20250711210000-add-userid-to-scans.js
@@ -7,9 +7,9 @@ module.exports = {
     await queryInterface.addColumn('Scans', 'user_id', {
       type: Sequelize.INTEGER,
       allowNull: false,
-      // 建立與 Users 表的外部索引鍵關聯
+      // 建立與 users 表的外部索引鍵關聯
       references: {
-        model: 'Users', // 確認您的使用者資料表名稱為 'Users'
+        model: 'users', // 表格名稱應與 User model 的 tableName 相同
         key: 'id',
       },
       onUpdate: 'CASCADE',

--- a/express/migrations/YYYYMMDDHHMMSS-create-usage-record.js
+++ b/express/migrations/YYYYMMDDHHMMSS-create-usage-record.js
@@ -13,7 +13,7 @@ module.exports = {
         type: Sequelize.INTEGER,
         allowNull: false,
         references: {
-          model: 'Users',
+          model: 'users',
           key: 'id',
         },
         onUpdate: 'CASCADE',

--- a/express/models/scan.js
+++ b/express/models/scan.js
@@ -46,7 +46,7 @@ module.exports = (sequelize, DataTypes) => {
     user_id: {
       type: DataTypes.INTEGER,
       allowNull: false,
-      references: { model: 'Users', key: 'id' }
+      references: { model: 'users', key: 'id' }
     },
     status: {
       type: DataTypes.STRING,

--- a/express/models/usersubscription.js
+++ b/express/models/usersubscription.js
@@ -9,7 +9,7 @@ module.exports = (sequelize, DataTypes) => {
   }
   UserSubscription.init({
     id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
-    user_id: { type: DataTypes.INTEGER, allowNull: false, references: { model: 'Users', key: 'id' } },
+    user_id: { type: DataTypes.INTEGER, allowNull: false, references: { model: 'users', key: 'id' } },
     plan_id: { type: DataTypes.INTEGER, allowNull: false, references: { model: 'SubscriptionPlans', key: 'id' } },
     status: DataTypes.STRING,
     started_at: DataTypes.DATE,


### PR DESCRIPTION
## Summary
- ensure migrations refer to `users` table name consistently
- update model definitions for `scan` and `usersubscription`

## Testing
- `pnpm install`
- `pnpm test` *(fails: sharp module install issues)*

------
https://chatgpt.com/codex/tasks/task_e_687111ed43548324911588a442eee268