### PR TITLE
Fix table name case & enhance protect logging

### DIFF
--- a/express/models/ManualReport.js
+++ b/express/models/ManualReport.js
@@ -28,7 +28,7 @@ module.exports = (sequelize, DataTypes) => {
     },
     response: DataTypes.TEXT
   }, {
-    tableName: 'ManualReports'
+    tableName: 'manual_reports'
   });
 
   return ManualReport;

--- a/express/models/Payment.js
+++ b/express/models/Payment.js
@@ -31,7 +31,7 @@ module.exports = (sequelize) => {
       defaultValue: 'PENDING'
     }
   }, {
-    tableName: 'Payments',
+    tableName: 'payments',
     timestamps: true
   });
   return Payment;

--- a/express/models/ScanTask.js
+++ b/express/models/ScanTask.js
@@ -9,8 +9,8 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.INTEGER,
       allowNull: false,
       references: {
-        // **FIX**: 確保參考的資料表名稱是 'Files' (首字母大寫的複數形式)
-        model: 'Files',
+        // use consistent lowercase table name
+        model: 'files',
         key: 'id',
       },
     },

--- a/express/models/subscriptionplan.js
+++ b/express/models/subscriptionplan.js
@@ -20,7 +20,7 @@ module.exports = (sequelize, DataTypes) => {
   }, {
     sequelize,
     modelName: 'SubscriptionPlan',
-    tableName: 'SubscriptionPlans',
+    tableName: 'subscription_plans',
     underscored: true,
   });
   return SubscriptionPlan;

--- a/express/models/usersubscription.js
+++ b/express/models/usersubscription.js
@@ -10,14 +10,14 @@ module.exports = (sequelize, DataTypes) => {
   UserSubscription.init({
     id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
     user_id: { type: DataTypes.INTEGER, allowNull: false, references: { model: 'users', key: 'id' } },
-    plan_id: { type: DataTypes.INTEGER, allowNull: false, references: { model: 'SubscriptionPlans', key: 'id' } },
+    plan_id: { type: DataTypes.INTEGER, allowNull: false, references: { model: 'subscription_plans', key: 'id' } },
     status: DataTypes.STRING,
     started_at: DataTypes.DATE,
     expires_at: DataTypes.DATE,
   }, {
     sequelize,
     modelName: 'UserSubscription',
-    tableName: 'UserSubscriptions',
+    tableName: 'user_subscriptions',
     underscored: true,
   });
   return UserSubscription;

--- a/express/routes/protect.js
+++ b/express/routes/protect.js
@@ -149,8 +149,12 @@ router.post('/step1', upload.single('file'), async (req, res) => {
             }));
         }
 
-        logger.error('[Protect Step1] Failed:', errorDetails);
-        res.status(error.status || 500).json({ 
+        logger.error('[Protect Step1] Failed:', {
+            error: error.message,
+            stack: error.stack,
+            ...errorDetails
+        });
+        res.status(error.status || 500).json({
             error: error.message || '處理試用檔案時發生內部錯誤。',
             details: errorDetails
         });


### PR DESCRIPTION
## Summary
- normalize several Sequelize model table names to lowercase for database consistency
- adjust ScanTask foreign key reference to lower-case table name
- improve error logging details in protect route

## Testing
- `npm install` *(fails: test suite fails due to missing credentials)*
- `npm test` *(fails: test suite fails due to missing credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68720d18ef04832495f183583a20f596