### PR TITLE
Fix user ID migration and improve logging

### DIFF
--- a/express/migrations/20250711210000-add-userid-to-scans.js
+++ b/express/migrations/20250711210000-add-userid-to-scans.js
@@ -3,25 +3,43 @@
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up (queryInterface, Sequelize) {
-    console.log('Adding "user_id" column to "Scans" table...');
-    await queryInterface.addColumn('Scans', 'user_id', {
-      type: Sequelize.INTEGER,
-      allowNull: false,
-      // 建立與 users 表的外部索引鍵關聯
-      references: {
-        model: 'users', // 表格名稱應與 User model 的 tableName 相同
-        key: 'id',
-      },
-      onUpdate: 'CASCADE',
-      onDelete: 'CASCADE',
-      // 將此欄位放在 file_id 之後，讓結構更清晰 (可選)
-      after: 'file_id' 
-    });
-    console.log('Column "user_id" has been successfully added.');
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      const columns = await queryInterface.describeTable('Scans');
+      if (!columns.user_id) {
+        console.log('Adding "user_id" column to "Scans" table...');
+        await queryInterface.addColumn('Scans', 'user_id', {
+          type: Sequelize.INTEGER,
+          allowNull: false,
+          references: {
+            model: 'users',
+            key: 'id',
+          },
+          onUpdate: 'CASCADE',
+          onDelete: 'CASCADE',
+          after: 'file_id'
+        }, { transaction });
+        console.log('Column "user_id" has been successfully added.');
+      }
+      await transaction.commit();
+    } catch (err) {
+      await transaction.rollback();
+      throw err;
+    }
   },
 
   async down (queryInterface, Sequelize) {
-    console.log('Removing "user_id" column from "Scans" table...');
-    await queryInterface.removeColumn('Scans', 'user_id');
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      const columns = await queryInterface.describeTable('Scans');
+      if (columns.user_id) {
+        console.log('Removing "user_id" column from "Scans" table...');
+        await queryInterface.removeColumn('Scans', 'user_id', { transaction });
+      }
+      await transaction.commit();
+    } catch (err) {
+      await transaction.rollback();
+      throw err;
+    }
   }
 };

--- a/express/routes/users.js
+++ b/express/routes/users.js
@@ -31,7 +31,8 @@ router.get('/:userId', async (req, res) => {
     }
     res.json(user);
   } catch (error) {
-    res.status(500).json({ error: 'Failed to retrieve user' });
+    console.error(`Failed to retrieve user ${userId}:`, error);
+    res.status(500).json({ error: 'Failed to retrieve user', details: error.message });
   }
 });
 


### PR DESCRIPTION
## Summary
- handle repeated `user_id` column in scans migration
- expand error details for fetching user by ID

## Testing
- `npm test --silent` *(fails: gcp-vision.json missing)*
- `npx turbo run test --filter=express` *(failed: lockfile not found)*

------
https://chatgpt.com/codex/tasks/task_e_68747ca81098832488d17ada6a85b52d