### PR TITLE
Fix Sequelize table name mismatches

### DIFF
--- a/express/models/File.js
+++ b/express/models/File.js
@@ -17,7 +17,8 @@ module.exports = (sequelize, DataTypes) => {
     user_id: {
       type: DataTypes.INTEGER,
       allowNull: false,
-      references: { model: 'users', key: 'id' },
+      // 避免表名大小寫不一致導致外鍵失敗
+      references: { model: 'Users', key: 'id' },
     },
     filename: DataTypes.STRING,
     title: DataTypes.STRING,
@@ -33,7 +34,7 @@ module.exports = (sequelize, DataTypes) => {
   }, {
     sequelize,
     modelName: 'File',
-    tableName: 'files',
+    tableName: 'Files',
     underscored: true,
   });
   return File;

--- a/express/models/scan.js
+++ b/express/models/scan.js
@@ -46,7 +46,7 @@ module.exports = (sequelize, DataTypes) => {
     user_id: {
       type: DataTypes.INTEGER,
       allowNull: false,
-      references: { model: 'users', key: 'id' }
+      references: { model: 'Users', key: 'id' }
     },
     status: {
       type: DataTypes.STRING,

--- a/express/models/usagerecord.js
+++ b/express/models/usagerecord.js
@@ -17,7 +17,8 @@ module.exports = (sequelize, DataTypes) => {
     user_id: {
       type: DataTypes.INTEGER,
       allowNull: false,
-      references: { model: 'users', key: 'id' }
+      // 與遷移檔案保持一致
+      references: { model: 'Users', key: 'id' }
     },
     feature_code: {
       type: DataTypes.ENUM('image_upload', 'scan', 'dmca_takedown'),

--- a/express/models/user.model.js
+++ b/express/models/user.model.js
@@ -53,7 +53,7 @@ module.exports = (sequelize, DataTypes) => {
       defaultValue: 10
     }
   }, {
-    tableName: 'users',
+    tableName: 'Users',
     indexes: [
       { unique: true, fields: ['email'] },
       { unique: true, fields: ['phone'] }

--- a/express/models/usersubscription.js
+++ b/express/models/usersubscription.js
@@ -12,7 +12,7 @@ module.exports = (sequelize, DataTypes) => {
     user_id: {
       type: DataTypes.INTEGER,
       allowNull: false,
-      references: { model: 'users', key: 'id' }
+      references: { model: 'Users', key: 'id' }
     },
     plan_id: { type: DataTypes.INTEGER, allowNull: false, references: { model: 'SubscriptionPlans', key: 'id' } },
     status: DataTypes.STRING,


### PR DESCRIPTION
## Summary
- align model table names and FK references with the migration scripts

## Testing
- `npm test --silent` *(fails: turbo not found)*
- `npx jest` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874cd4b20088324becddc066cb1d22a