### PR TITLE
Fix scanning flow & config

### DIFF
--- a/.env
+++ b/.env
@@ -90,9 +90,9 @@ BING_ENDPOINT=https://soozookaizokuhunter.cognitiveservices.azure.com/
 
 # --- RapidAPI 社群媒體搜尋設定 ---
 RAPIDAPI_YOUTUBE_URL=https://keyword-research-for-youtube.p.rapidapi.com/ytags.php
-RAPIDAPI_TIKTOK_URL=
-RAPIDAPI_INSTAGRAM_URL=
-RAPIDAPI_FACEBOOK_URL=
+RAPIDAPI_TIKTOK_URL=https://tiktok-video-no-watermark2.p.rapidapi.com/
+RAPIDAPI_INSTAGRAM_URL=https://instagram-scraper-api2.p.rapidapi.com/v1/
+RAPIDAPI_FACEBOOK_URL=https://facebook-scraper-api.p.rapidapi.com/v1/
 RAPIDAPI_GLOBAL_IMAGE_SEARCH_URL=https://global-image-search-with-keywords.p.rapidapi.com/v1/google_image_search/
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,10 @@ services:
     depends_on:
       suzoo_express:
         condition: service_healthy
+      suzoo_rabbitmq:
+        condition: service_healthy
+      suzoo_redis:
+        condition: service_healthy
     networks:
       - suzoo-network
     # [新增] 為 Worker 增加健康檢查，確保其不僅啟動，而且能正常回應


### PR DESCRIPTION
## Summary
- add RapidAPI endpoint URLs in `.env`
- ensure worker depends on Redis and RabbitMQ
- verify scan results with fingerprint match

## Testing
- `pnpm --filter suzoo-express test` *(fails: sharp module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874e0608d548324afb6972a7b9a8df5