### PR TITLE
Fix scanning workflow

### DIFF
--- a/express/models/index.js
+++ b/express/models/index.js
@@ -37,12 +37,7 @@ fs.readdirSync(__dirname)
     const isNotThisFile = file !== basename;
     const isJsFile = file.slice(-3) === '.js';
     
-    // [★★ 關鍵修正 ★★]
-    // 過濾掉有問題的 scantask.js 模型檔案。
-    // 這可以防止它被 Sequelize 載入，從而避免資料庫同步時發生崩潰。
-    const isNotProblematicModel = file.toLowerCase() !== 'scantask.js';
-
-    return isVisibleFile && isNotThisFile && isJsFile && isNotProblematicModel;
+    return isVisibleFile && isNotThisFile && isJsFile;
   })
   .forEach(file => {
     try {

--- a/express/package.json
+++ b/express/package.json
@@ -38,6 +38,7 @@
     "sharp": "^0.32.1",
     "tineye-api": "^1.1.2",
     "web3": "^1.10.0",
+    "socket.io-client": "^4.7.2",
     "socket.io": "^4.7.2",
     "winston": "^3.13.0"
   },

--- a/express/routes/scans.js
+++ b/express/routes/scans.js
@@ -82,11 +82,17 @@ router.post('/:fileId', auth, async (req, res) => {
             status: 'pending'
         });
 
+        const task = await db.ScanTask.create({
+            file_id: file.id,
+            status: 'PENDING'
+        });
+
         await db.UsageRecord.create({ user_id: userId, feature_code: 'scan' });
 
         // 將所有需要的資訊都發送到佇列
         await queueService.sendToQueue({
-            taskId: scan.id,
+            taskId: task.id,
+            scanId: scan.id,
             fileId: file.id,
             userId: userId,
             ipfsHash: file.ipfs_hash,
@@ -94,7 +100,7 @@ router.post('/:fileId', auth, async (req, res) => {
             keywords: file.keywords,
         });
 
-        res.status(202).json({ message: '掃描任務已重新派發', scanId: scan.id });
+        res.status(202).json({ message: '掃描任務已重新派發', scanId: scan.id, taskId: task.id });
     } catch (err) {
         logger.error(`[Scan API] Failed to re-dispatch scan task for file ${fileId}:`, err);
         res.status(500).json({ error: '無法派發掃描任務' });

--- a/express/worker.js
+++ b/express/worker.js
@@ -11,6 +11,7 @@ process.on('unhandledRejection', (reason, promise) => {
 
 const http = require('http');
 const express = require('express');
+const { default: ioClient } = require('socket.io-client');
 const db = require('./models');
 const logger = require('./utils/logger');
 const queueService = require('./services/queue.service');
@@ -22,30 +23,48 @@ app.get('/health', (req, res) => res.status(200).json({ status: 'ok' }));
 const server = http.createServer(app);
 
 const WORKER_PORT = process.env.WORKER_PORT || 3001;
+const SOCKET_URL = process.env.SOCKET_IO_URL || process.env.EXPRESS_BASE_URL || 'http://suzoo_express:3000';
+const socket = ioClient(SOCKET_URL, { transports: ['websocket'] });
+
+socket.on('connect', () => logger.info('[Worker] Connected to Socket.IO server'));
+socket.on('disconnect', () => logger.warn('[Worker] Disconnected from Socket.IO server'));
+
+function emitUpdate(scanId, payload) {
+    try {
+        socket.emit(`scan-update-${scanId}`, payload);
+    } catch (err) {
+        logger.warn('[Worker] Failed to emit socket update:', err.message);
+    }
+}
 
 async function processScanTask(task) {
-    const { taskId, fileId, userId } = task;
+    const { taskId, scanId, fileId, userId } = task;
     logger.info(`[Worker] Received task ${taskId}: Processing scan for File ID ${fileId}`);
 
     try {
-        await db.Scan.update({ status: 'processing', progress: 10, started_at: new Date() }, { where: { id: taskId } });
+        await db.Scan.update({ status: 'processing', progress: 10, started_at: new Date() }, { where: { id: scanId } });
+        await db.ScanTask.update({ status: 'PROCESSING' }, { where: { id: taskId } });
+        emitUpdate(scanId, { status: 'processing', progress: 10 });
 
         const fileRecord = await db.File.findByPk(fileId);
         if (!fileRecord) throw new Error(`File record ${fileId} not found in DB.`);
 
-        await db.Scan.update({ progress: 20 }, { where: { id: taskId } });
+        await db.Scan.update({ progress: 20 }, { where: { id: scanId } });
+        emitUpdate(scanId, { status: 'processing', progress: 20 });
 
         const imageBuffer = await ipfsService.getFile(fileRecord.ipfs_hash);
         if (!imageBuffer) throw new Error(`Failed to get file from IPFS with hash ${fileRecord.ipfs_hash}.`);
 
-        await db.Scan.update({ progress: 40 }, { where: { id: taskId } });
+        await db.Scan.update({ progress: 40 }, { where: { id: scanId } });
+        emitUpdate(scanId, { status: 'processing', progress: 40 });
 
         const scanResult = await scannerService.scanByImage(imageBuffer, {
             fingerprint: fileRecord.fingerprint,
             keywords: fileRecord.keywords,
         });
 
-        await db.Scan.update({ progress: 80 }, { where: { id: taskId } });
+        await db.Scan.update({ progress: 80 }, { where: { id: scanId } });
+        emitUpdate(scanId, { status: 'processing', progress: 80 });
 
         const finalStatus = 'completed';
 
@@ -57,7 +76,9 @@ async function processScanTask(task) {
                 results: scanResult.results || {},
                 errors: scanResult.errors || []
             }
-        }, { where: { id: taskId } });
+        }, { where: { id: scanId } });
+        await db.ScanTask.update({ status: 'COMPLETED', result_json: scanResult }, { where: { id: taskId } });
+        emitUpdate(scanId, { status: 'completed', progress: 100, result: scanResult });
 
         logger.info(`[Worker] Task ${taskId} completed successfully.`);
         return true;
@@ -69,7 +90,9 @@ async function processScanTask(task) {
             completed_at: new Date(),
             progress: 100,
             result: { error: error.message }
-        }, { where: { id: taskId } });
+        }, { where: { id: scanId } });
+        await db.ScanTask.update({ status: 'FAILED', error_message: error.message }, { where: { id: taskId } });
+        emitUpdate(scanId, { status: 'failed', progress: 100, error: error.message });
         return true;
     }
 }


### PR DESCRIPTION
## Summary
- use ScanTask table for queue tracking
- push realtime progress with Socket.IO
- update worker to track Scan and ScanTask states
- enable ScanTask model loading
- add socket.io-client dependency

## Testing
- `npx --yes turbo run test` *(fails: Lockfile not found)*

------
https://chatgpt.com/codex/tasks/task_e_687507402e988324b1556f4508e63714