### PR TITLE
Fix worker missing socket.io-client error

### DIFF
--- a/express/worker.js
+++ b/express/worker.js
@@ -11,7 +11,13 @@ process.on('unhandledRejection', (reason, promise) => {
 
 const http = require('http');
 const express = require('express');
-const io = require('socket.io-client');
+let io;
+try {
+    io = require('socket.io-client');
+} catch (err) {
+    console.error('[Worker] socket.io-client not installed:', err);
+    process.exit(1);
+}
 const db = require('./models');
 const logger = require('./utils/logger');
 const queueService = require('./services/queue.service');


### PR DESCRIPTION
## Summary
- handle missing `socket.io-client` gracefully in `worker.js`

## Testing
- `npm test --silent` *(fails: ENOENT no such file or directory gcp-vision.json)*

------
https://chatgpt.com/codex/tasks/task_e_687517aae5308324b6c21fc229eaa7da