### PR TITLE
Improve missing dependency message

### DIFF
--- a/express/worker.js
+++ b/express/worker.js
@@ -15,7 +15,7 @@ let io;
 try {
     io = require('socket.io-client');
 } catch (err) {
-    console.error('[Worker] socket.io-client not installed:', err);
+    console.error('[Worker] FATAL: socket.io-client missing. Verify Docker image build or run `npm install`.', err);
     process.exit(1);
 }
 const db = require('./models');


### PR DESCRIPTION
## Summary
- log a clearer fatal message when `socket.io-client` is missing

## Testing
- `npm test` *(fails: Vision suite has no tests and `step2.test.js` assertions fail)*

------
https://chatgpt.com/codex/tasks/task_e_68751c9358a08324b846167c1a4bf4e0