### PR TITLE
Fix api client imports and jwt decode

### DIFF
--- a/frontend/src/AuthContext.jsx
+++ b/frontend/src/AuthContext.jsx
@@ -1,8 +1,8 @@
 import React, { createContext, useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 // [關鍵修正] 確保使用 jwt-decode v4+ 的正確具名引入方式
-import { jwtDecode } from 'jwt-decode';
-import apiClient from './services/apiClient';
+import jwtDecode from 'jwt-decode';
+import apiClient from './utils/apiClient';
 
 export const AuthContext = createContext(null);
 

--- a/frontend/src/pages/ProtectStep1.jsx
+++ b/frontend/src/pages/ProtectStep1.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled, { keyframes } from 'styled-components';
-import apiClient from '../services/apiClient';
+import apiClient from '../utils/apiClient';
 
 const gradientFlow = keyframes`
   0% { background-position: 0% 50%; }


### PR DESCRIPTION
## Summary
- import jwtDecode correctly from `jwt-decode`
- fix api client path to use `utils/apiClient`

## Testing
- `npm test` *(fails: Could not resolve workspaces; no tests run)*

------
https://chatgpt.com/codex/tasks/task_e_687609389de0832496d869a492f830e0