### PR TITLE
Fix API URL for frontend builds

### DIFF
--- a/.env
+++ b/.env
@@ -9,6 +9,7 @@ COMPOSE_PROJECT_NAME=soozookaizokuhunter
 PUBLIC_HOST=https://suzookaizokuhunter.com
 EXPRESS_BASE_URL=http://suzoo_express:3000
 FASTAPI_URL=http://suzoo_fastapi:8000
+REACT_APP_API_URL=
 
 ########################################
 # 預設管理員帳號 (用於首次啟動)

--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,7 @@ DMCA_BANNED_FINGERPRINTS=d41d8cd98f00b204e9800998ecf8427e
 # FastAPI
 ########################################
 FASTAPI_URL=http://suzoo_fastapi:8000
+REACT_APP_API_URL=
 
 ########################################
 # Express 認證

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+      args:
+        - REACT_APP_API_URL=${REACT_APP_API_URL}
     ports:
       - "80:80"
     volumes:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,8 +13,9 @@ RUN npm install --package-lock-only && \
 # 再複製其餘原始碼
 COPY . .
 
-# 將後端 API 位址在建置期注入；預設為 dev 值
-ARG REACT_APP_API_URL=http://localhost:3000
+# 將後端 API 位址在建置期注入；預設為空字串，
+# 使前端在正式環境透過相對路徑呼叫 API
+ARG REACT_APP_API_URL=
 ENV REACT_APP_API_URL=${REACT_APP_API_URL}
 
 # 產生正式版靜態檔


### PR DESCRIPTION
## Summary
- default API URL for frontend to '' so React apps access API via relative path
- pass API build arg from docker-compose
- add `REACT_APP_API_URL` placeholder in `.env` and `.env.example`

## Testing
- `pnpm install`
- `pnpm test` *(fails: sharp module & vision credentials)*

------
https://chatgpt.com/codex/tasks/task_e_687611ad50488324a7fec1aa88c31990