### PR TITLE
Add ErrorBoundary and safety checks

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 ARG REACT_APP_API_URL
 ENV REACT_APP_API_URL=$REACT_APP_API_URL
 
-RUN npm run build
+RUN npm run build -- --source-map
 
 ########## 2️⃣ Production Stage ##########################################
 FROM nginx:alpine

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -26,6 +26,7 @@ import ProtectStep4 from './pages/ProtectStep4';
 
 // --- Components ---
 import ProtectedRoute from './components/ProtectedRoute';
+import ErrorBoundary from './ErrorBoundary';
 
 // --- 全域樣式 ---
 const GlobalStyle = createGlobalStyle`
@@ -164,8 +165,9 @@ function App() {
       <GlobalStyle />
       <AuthProvider>
         <BrowserRouter>
-          <Routes>
-            <Route element={<RootLayout />}>
+          <ErrorBoundary>
+            <Routes>
+              <Route element={<RootLayout />}>
               {/* --- 公開路由 --- */}
               <Route index element={<HomePage />} />
               <Route path="login" element={<LoginPage />} />
@@ -195,7 +197,8 @@ function App() {
               {/* --- 404 頁面 --- */}
               <Route path="*" element={<NotFoundPage />} />
             </Route>
-          </Routes>
+            </Routes>
+          </ErrorBoundary>
         </BrowserRouter>
       </AuthProvider>
     </>

--- a/frontend/src/ErrorBoundary.jsx
+++ b/frontend/src/ErrorBoundary.jsx
@@ -1,0 +1,37 @@
+import React, { Component } from 'react';
+
+class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null, errorInfo: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    this.setState({ error, errorInfo });
+    console.error('ErrorBoundary caught an error', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div style={{ padding: '20px', textAlign: 'center', color: 'white', backgroundColor: '#1e1e1e' }}>
+          <h2>\u767c\u751f\u932f\u8aa4</h2>
+          <p>\u8acb\u5237\u65b0\u9801\u9762\u6216\u7a0d\u5f8c\u518d\u8a66\u3002</p>
+          <details style={{ whiteSpace: 'pre-wrap', textAlign: 'left' }}>
+            {this.state.error && this.state.error.toString()}
+            <br />
+            {this.state.errorInfo?.componentStack}
+          </details>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -8,7 +8,7 @@ import styled from 'styled-components';
 
 function DashboardPage() {
   const { token, logout } = useContext(AuthContext);
-  const [dashboardData, setDashboardData] = useState(null);
+  const [dashboardData, setDashboardData] = useState({ userInfo: null, protectedContent: [] });
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(true);
   const [showBulkUploader, setShowBulkUploader] = useState(false);
@@ -64,7 +64,7 @@ function DashboardPage() {
 
   if (isLoading) return <div style={styles.pageContainer}><h2>載入中...</h2></div>;
   if (error) return <div style={styles.pageContainer}><p style={{color: 'red'}}>{error}</p></div>;
-  if (!dashboardData) return null;
+  if (!dashboardData.userInfo) return null;
 
   const { userInfo, protectedContent } = dashboardData;
 

--- a/frontend/src/pages/ProtectStep3.jsx
+++ b/frontend/src/pages/ProtectStep3.jsx
@@ -179,6 +179,22 @@ export default function ProtectStep3() {
     const navigate = useNavigate();
     const location = useLocation();
 
+    if (!location.state) {
+        return (
+            <PageWrapper>
+                <Container>
+                    <Title>錯誤</Title>
+                    <p>缺少必要的狀態數據，請返回上一步。</p>
+                    <ButtonRow>
+                        <NavButton onClick={() => navigate('/protect/step1')}>
+                            返回第一步
+                        </NavButton>
+                    </ButtonRow>
+                </Container>
+            </PageWrapper>
+        );
+    }
+
     const { scanId, step1Data } = location.state || {};
     
     const [loading, setLoading] = useState(true);


### PR DESCRIPTION
## Summary
- add ErrorBoundary component and use it in App
- give Dashboard default state
- add location state guard for ProtectStep3
- enable source maps in frontend Dockerfile for easier debugging

## Testing
- `npx turbo run lint` *(failed: Need to install turbo)*
- `npm test` *(failed: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_687693e2d5b88324896d7f2048ef09a1