### PR TITLE
Add blockchain healthcheck and retry tweaks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,8 @@ services:
         condition: service_healthy
       suzoo_rabbitmq:
         condition: service_healthy
+      suzoo_ganache:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:3000/health || exit 1"]
       interval: 30s
@@ -144,6 +146,11 @@ services:
     ports: ["8545:8545"]
     networks:
       - suzoo-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8545"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
     restart: unless-stopped
 
   suzoo_fastapi:

--- a/express/utils/chain.js
+++ b/express/utils/chain.js
@@ -3,6 +3,10 @@ const Web3 = require('web3');
 const { getABI } = require('./contract');
 const logger = require('./logger');
 
+// Retry configuration for blockchain connection
+const MAX_RETRIES = 15;  // Increased from 5
+const RETRY_DELAY = 5000; // 5 seconds
+
 const rpcUrl = process.env.BLOCKCHAIN_RPC_URL;
 const privateKey = process.env.BLOCKCHAIN_PRIVATE_KEY;
 const contractAddress = process.env.CONTRACT_ADDRESS;
@@ -12,7 +16,7 @@ let contract;
 let account;
 let isInitialized = false;
 
-async function initializeBlockchainService(retries = 5, delay = 5000) {
+async function initializeBlockchainService(retries = MAX_RETRIES, delay = RETRY_DELAY) {
     if (isInitialized) return;
 
     if (!privateKey || !contractAddress || !rpcUrl) {


### PR DESCRIPTION
## Summary
- add healthcheck to Ganache container
- ensure Express waits for Ganache to be healthy
- increase blockchain connection retries to 15

## Testing
- `pnpm test` *(fails: suzoo-express tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68773561d2d88324a3bfd572f9782c51