### PR TITLE
Fix ganache health check via custom image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,7 +140,9 @@ services:
 
   suzoo_ganache:
     container_name: suzoo_ganache
-    image: trufflesuite/ganache:latest
+    build:
+      context: ./ganache
+      dockerfile: Dockerfile
     command: ["--host", "0.0.0.0", "--wallet.accounts", "${BLOCKCHAIN_PRIVATE_KEY},1000000000000000000000"]
     env_file: .env
     ports: ["8545:8545"]


### PR DESCRIPTION
## Summary
- build Ganache from local Dockerfile so curl is installed

## Testing
- `pnpm install`
- `pnpm test` *(fails: missing `/workspace/soozookaizokuhunter/credentials/gcp-vision.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6877535cd74483249fa75da4b65665d6