### PR TITLE
Fix express startup db sync

### DIFF
--- a/express/seed.js
+++ b/express/seed.js
@@ -7,7 +7,7 @@ async function seedDatabase() {
     const Plan = db.Plan || db.Plans;
 
     if (!Role || !Plan) {
-      const models = Object.keys(db).filter(key => !['sequelize', 'Sequelize', 'syncDatabase'].includes(key));
+      const models = Object.keys(db).filter(key => !['sequelize', 'Sequelize'].includes(key));
       throw new Error(`Role/Plan models not found. Available models: ${models.join(', ')}`);
     }
 

--- a/express/server.js
+++ b/express/server.js
@@ -86,7 +86,8 @@ async function startServer() {
     logger.info('[Startup] Initializing database connection...');
     await connectWithRetry();
 
-    await db.syncDatabase({ alter: true });
+    // Synchronize database models
+    await db.sequelize.sync({ alter: true });
     
     // 直接呼叫 seeder，它會自己處理模型的載入
     await seedDatabase();


### PR DESCRIPTION
## Summary
- replace removed `syncDatabase` call with `db.sequelize.sync`
- update seeder to account for property removal

## Testing
- `pnpm install`
- `pnpm test` *(fails: Vision test missing credentials)*

------
https://chatgpt.com/codex/tasks/task_e_6878a1b4a1b883249ca1b07677e73a86