### PR TITLE
Fix dashboard auth and lock API key page

### DIFF
--- a/express/routes/users.js
+++ b/express/routes/users.js
@@ -28,6 +28,9 @@ router.get('/profile', auth, async (req, res) => {
 
 // POST /api/users/api-keys
 router.post('/api-keys', auth, async (req, res) => {
+    if (req.user.role !== 'admin') {
+        return res.status(403).json({ error: '只有管理員可以執行此操作' });
+    }
     const { keys } = req.body;
     const userId = req.user.id;
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -107,7 +107,9 @@ const Layout = () => {
                     ) : (
                         <>
                             <NavLink to="/dashboard">儀表板</NavLink>
-                            <NavLink to="/settings/api-keys">API 設定</NavLink>
+                            {user.role === 'admin' && (
+                                <NavLink to="/settings/api-keys">API 設定</NavLink>
+                            )}
                             {user.role === 'admin' && (
                                 <NavLink to="/admin/dashboard">管理面板</NavLink>
                             )}
@@ -147,9 +149,9 @@ function App() {
               <Route element={<ProtectedRoute allowedRoles={['user', 'admin']} />}>
                 <Route path="dashboard" element={<DashboardPage />} />
                 <Route path="file/:fileId" element={<FileDetailPage />} />
-                <Route path="settings/api-keys" element={<SettingsPage />} />
               </Route>
               <Route element={<ProtectedRoute allowedRoles={['admin']} />}>
+                <Route path="settings/api-keys" element={<SettingsPage />} />
                 <Route path="admin/dashboard" element={<AdminDashboardPage />} />
                 <Route path="admin/users" element={<AdminUsersPage />} />
               </Route>

--- a/frontend/src/AuthContext.jsx
+++ b/frontend/src/AuthContext.jsx
@@ -5,19 +5,22 @@ export const AuthContext = createContext(null);
 
 export const AuthProvider = ({ children }) => {
     const [user, setUser] = useState(null);
+    const [token, setToken] = useState(null);
     const [loading, setLoading] = useState(true);
 
     const logout = useCallback(() => {
         localStorage.removeItem('token');
+        setToken(null);
         setUser(null);
     }, []);
 
     useEffect(() => {
         try {
-            const token = localStorage.getItem('token');
-            if (token) {
-                const decodedToken = jwtDecode(token);
+            const stored = localStorage.getItem('token');
+            if (stored) {
+                const decodedToken = jwtDecode(stored);
                 if (decodedToken.exp * 1000 > Date.now()) {
+                    setToken(stored);
                     setUser({
                         id: decodedToken.id,
                         email: decodedToken.email,
@@ -36,10 +39,11 @@ export const AuthProvider = ({ children }) => {
         }
     }, [logout]);
 
-    const login = (token) => {
+    const login = (tokenValue) => {
         try {
-            localStorage.setItem('token', token);
-            const decodedToken = jwtDecode(token);
+            localStorage.setItem('token', tokenValue);
+            setToken(tokenValue);
+            const decodedToken = jwtDecode(tokenValue);
             setUser({
                 id: decodedToken.id,
                 email: decodedToken.email,
@@ -64,6 +68,7 @@ export const AuthProvider = ({ children }) => {
 
     const authContextValue = {
         user,
+        token,
         login,
         logout,
         updateApiKeysInState,


### PR DESCRIPTION
## Summary
- keep user token in `AuthContext`
- show API key settings only to admins
- restrict API key API to admin role

## Testing
- `npx turbo run test` *(fails: Needs to install packages)*

------
https://chatgpt.com/codex/tasks/task_e_68790511ce948324bf7fd7d2b17cb057