### PR TITLE
Fix API base paths in frontend

### DIFF
--- a/frontend/src/components/BulkUploader.jsx
+++ b/frontend/src/components/BulkUploader.jsx
@@ -116,7 +116,7 @@ function BulkUploader({ onClose, onUploadComplete }) {
 
     try {
       // [核心修正] 直接使用 apiClient，它會自動處理 token 和 headers
-      const response = await apiClient.post('/api/protect/batch-protect', formData);
+      const response = await apiClient.post('/protect/batch-protect', formData);
       
       const data = response.data;
       

--- a/frontend/src/pages/AdminLoginPage.jsx
+++ b/frontend/src/pages/AdminLoginPage.jsx
@@ -82,7 +82,7 @@ export default function AdminLogin() {
     }
 
     try {
-      const response = await apiClient.post('/api/admin/login', {
+      const response = await apiClient.post('/admin/login', {
         identifier: identifier.trim(),
         password,
       });

--- a/frontend/src/pages/AdminUsersPage.jsx
+++ b/frontend/src/pages/AdminUsersPage.jsx
@@ -29,7 +29,7 @@ function AdminUsersPage() {
     const fetchUsers = async () => {
         setIsLoading(true);
         try {
-            const response = await apiClient.get('/api/admin/users');
+            const response = await apiClient.get('/admin/users');
             setUsers(response.data);
         } catch (err) {
             setError(err.response?.data?.error || 'Failed to fetch user list.');
@@ -49,7 +49,7 @@ function AdminUsersPage() {
         if (!window.confirm(`確定要將使用者 #${userId} 的方案更改為 ${newPlanCode} 嗎？`)) return;
 
         try {
-            await apiClient.put(`/api/admin/users/${userId}/subscription`, {
+            await apiClient.put(`/admin/users/${userId}/subscription`, {
                 planCode: newPlanCode
             });
             alert('方案更新成功！');

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -16,7 +16,7 @@ function DashboardPage() {
   const fetchDashboardData = async () => {
     setIsLoading(true);
     try {
-      const response = await apiClient.get('/api/dashboard');
+      const response = await apiClient.get('/dashboard');
       setDashboardData(response.data);
     } catch (err) {
       setError(err.response?.data?.error || err.message || '無法載入會員資料。');
@@ -53,7 +53,7 @@ function DashboardPage() {
 
     try {
       // 步驟 2: 向後端發送掃描請求
-      const res = await apiClient.get(`/api/scan/${fileId}`);
+      const res = await apiClient.get(`/scan/${fileId}`);
       alert(res.data.message || '掃描任務已成功派發！');
       // 可以在此處設定一個延遲來刷新，或等待 WebSocket 的自動更新
     } catch (err) {

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -29,7 +29,7 @@ const SettingsPage = () => {
     setStatus({ saving: true, success: false, error: null });
     
     try {
-      const response = await apiClient.post('/api/users/api-keys', { keys });
+      const response = await apiClient.post('/users/api-keys', { keys });
       updateApiKeysInState(response.data.keys);
       setStatus({ saving: false, success: true, error: null });
     } catch (error) {


### PR DESCRIPTION
## Summary
- correct apiClient request paths so they don't double-prefix `/api`
- ensure admin login, user management, dashboard, bulk uploader and settings save correctly call backend

## Testing
- `pnpm install`
- `pnpm test` *(fails: suzoo-express tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_68792ffed9b48324979637913cb63380