### PR TITLE
Fix ProtectStep1 import

### DIFF
--- a/frontend/src/apiClient.js
+++ b/frontend/src/apiClient.js
@@ -65,3 +65,11 @@ export async function apiRequest(path, options = {}) {
         throw error;
     }
 }
+
+// Provide a simple client wrapper for convenience
+export const apiClient = {
+    get: (path, options = {}) => apiRequest(path, { method: 'GET', ...options }),
+    post: (path, body, options = {}) => apiRequest(path, { method: 'POST', body, ...options }),
+    put: (path, body, options = {}) => apiRequest(path, { method: 'PUT', body, ...options }),
+    delete: (path, options = {}) => apiRequest(path, { method: 'DELETE', ...options }),
+};

--- a/frontend/src/pages/ProtectStep1.jsx
+++ b/frontend/src/pages/ProtectStep1.jsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-import apiClient from '../apiClient';
+// Use the named apiClient export to match updated apiClient.js
+import { apiClient } from '../apiClient';
 
 // [★★ 關鍵優化 ★★] - Wrapper to make page content look good in the new layout
 const PageWrapper = styled.div`


### PR DESCRIPTION
## Summary
- add `apiClient` helper wrappers
- use named `apiClient` import in ProtectStep1

## Testing
- `npm test` within `frontend`
- `npm run build` within `frontend`
- `npm run lint` *(fails: turbo not fully configured, telemetry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687a363b92cc8324ac9d1c3a5788637b