### PR TITLE
Fix Nginx proxy rules and clean up router

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -72,7 +72,7 @@ function App() {
               <Route path="/admin/login" element={<AdminLoginPage />} />
 
               {/* ===== 3. Protected User Dashboard (Dark Theme) ===== */}
-              <Route element={<ProtectedRoute allowedRoles={['user', 'admin']} /> }>
+              <Route element={<ProtectedRoute allowedRoles={['user', 'admin']} />}>
                 <Route element={<AppLayout />}>
                   <Route path="/dashboard" element={<DashboardPage />} />
                   <Route path="/file/:fileId" element={<FileDetailPage />} />
@@ -85,7 +85,7 @@ function App() {
               </Route>
               
               {/* ===== 4. Protected Admin Dashboard (Dark Theme) ===== */}
-              <Route element={<ProtectedRoute allowedRoles={['admin']} /> }>
+              <Route element={<ProtectedRoute allowedRoles={['admin']} />}>
                 <Route element={<AppLayout />}>
                   <Route path="/admin/dashboard" element={<AdminDashboardPage />} />
                   <Route path="/admin/users" element={<AdminUsersPage />} />

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -2,7 +2,6 @@ server {
     listen 80;
     server_name suzookaizokuhunter.com;
 
-    # Redirect HTTP to HTTPS
     location / {
         return 301 https://$host$request_uri;
     }
@@ -12,20 +11,15 @@ server {
     listen 443 ssl http2;
     server_name suzookaizokuhunter.com;
 
-    # SSL Certificates
     ssl_certificate /etc/letsencrypt/live/suzookaizokuhunter.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/suzookaizokuhunter.com/privkey.pem;
-
-    # SSL Configuration
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
-    # Root for static files
     root /usr/share/nginx/html;
-    index index.html index.htm;
+    index index.html;
 
-    # [★★ KEY FIX ★★] API Reverse Proxy
-    # Forward all requests for /api/ and /auth/ to the backend Express server
+    # [★★ KEY FIX 1 ★★] Forward /api requests directly
     location /api/ {
         proxy_pass http://suzoo_express:3000;
         proxy_set_header Host $host;
@@ -34,7 +28,9 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # [★★ KEY FIX 2 ★★] Rewrite and forward /auth requests to /api/auth
     location /auth/ {
+        rewrite /auth/(.*) /api/auth/$1 break;
         proxy_pass http://suzoo_express:3000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
- correct Nginx reverse proxy configuration to forward `/auth` to `/api/auth`
- clean up ProtectedRoute syntax in React router

## Testing
- `npm test` *(fails: `turbo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a7ba73b488324848edcf90068bdef