### PR TITLE
Refactor protect flow and login redirects

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -58,33 +58,34 @@ function App() {
           <GlobalStyle />
           <ErrorBoundary>
             <Routes>
-              {/* ===== 1. Public Pages (Light Theme) ===== */}
+              {/* ===== 1. 公開頁面 & 核心體驗流程 (亮色主題) ===== */}
               <Route element={<PublicLayout />}>
                 <Route path="/" element={<HomePage />} />
                 <Route path="/pricing" element={<PricingPage />} />
                 <Route path="/contact" element={<ContactPage />} />
                 <Route path="/blog/post-1" element={<BlogPostPage />} />
+                {/* [★★ 關鍵修正 ★★] 保護流程改為公開可訪問 */}
+                <Route path="/protect/step1" element={<ProtectStep1 />} />
+                <Route path="/protect/step2" element={<ProtectStep2 />} />
+                <Route path="/protect/step3" element={<ProtectStep3 />} />
+                <Route path="/protect/step4" element={<ProtectStep4 />} />
               </Route>
 
-              {/* ===== 2. Standalone Auth Pages (Dark Theme) ===== */}
+              {/* ===== 2. 獨立驗證頁面 (暗色主題) ===== */}
               <Route path="/login" element={<LoginPage />} />
               <Route path="/register" element={<RegisterPage />} />
               <Route path="/admin/login" element={<AdminLoginPage />} />
 
-              {/* ===== 3. Protected User Dashboard (Dark Theme) ===== */}
+              {/* ===== 3. 受保護的使用者後台 (暗色主題) ===== */}
               <Route element={<ProtectedRoute allowedRoles={['user', 'admin']} />}>
                 <Route element={<AppLayout />}>
                   <Route path="/dashboard" element={<DashboardPage />} />
                   <Route path="/file/:fileId" element={<FileDetailPage />} />
                   <Route path="/settings/api-keys" element={<SettingsPage />} />
-                  <Route path="/protect/step1" element={<ProtectStep1 />} />
-                  <Route path="/protect/step2" element={<ProtectStep2 />} />
-                  <Route path="/protect/step3" element={<ProtectStep3 />} />
-                  <Route path="/protect/step4" element={<ProtectStep4 />} />
                 </Route>
               </Route>
               
-              {/* ===== 4. Protected Admin Dashboard (Dark Theme) ===== */}
+              {/* ===== 4. 受保護的管理員後台 (暗色主題) ===== */}
               <Route element={<ProtectedRoute allowedRoles={['admin']} />}>
                 <Route element={<AppLayout />}>
                   <Route path="/admin/dashboard" element={<AdminDashboardPage />} />
@@ -92,7 +93,7 @@ function App() {
                 </Route>
               </Route>
 
-              {/* ===== 5. 404 Page ===== */}
+              {/* ===== 5. 404 頁面 ===== */}
               <Route path="*" element={<NotFoundPage />} />
             </Routes>
           </ErrorBoundary>

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useContext } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate, Link, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import { AuthContext } from '../AuthContext';
 import { apiClient } from '../apiClient';
@@ -77,10 +77,14 @@ const SwitchLink = styled(Link)`
 
 const LoginPage = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { login } = useContext(AuthContext);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
+
+  const from = location.state?.from?.pathname;
+  const redirectState = location.state;
 
   useEffect(() => {
     document.title = '登入 - SUZOO IP Guard';
@@ -92,11 +96,13 @@ const LoginPage = () => {
     try {
       const data = await apiClient.post('/auth/login', { email, password });
       login(data.token, data.user);
-      
-      if (data.user.role === 'admin') {
-        navigate('/admin/dashboard');
+
+      if (from) {
+        navigate(from, { state: redirectState, replace: true });
+      } else if (data.user.role === 'admin') {
+        navigate('/admin/dashboard', { replace: true });
       } else {
-        navigate('/dashboard');
+        navigate('/dashboard', { replace: true });
       }
     } catch (err) {
       setError(err.message || '登入失敗，請檢查您的憑證。');


### PR DESCRIPTION
## Summary
- move protect steps under public layout
- update ProtectStep4 with login/register callouts
- update LoginPage with redirect logic
- update RegisterPage to auto-login and redirect

## Testing
- `pnpm test` *(fails: Vision test failed)*

------
https://chatgpt.com/codex/tasks/task_e_687a81b3c0c88324a65e0cf7ac13204b