### PR TITLE
Fix ProtectStep1 UI and nginx upload limit

### DIFF
--- a/frontend/src/pages/ProtectStep1.jsx
+++ b/frontend/src/pages/ProtectStep1.jsx
@@ -7,7 +7,8 @@ const PageWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 2rem;
+  padding: 8rem 2rem 4rem;
+  background-color: ${({ theme }) => theme.colors.light.card};
 `;
 
 // [★★ 新增 ★★]
@@ -28,19 +29,19 @@ const BackButton = styled.button`
 `;
 
 const FormContainer = styled.div`
-  background-color: ${({ theme }) => theme.colors.dark.card};
-  border: 1px solid ${({ theme }) => theme.colors.dark.border};
+  background-color: ${({ theme }) => theme.colors.light.background};
+  border: 1px solid ${({ theme }) => theme.colors.light.border};
   border-radius: ${({ theme }) => theme.borderRadius};
   padding: 2.5rem;
   width: 100%;
   max-width: 600px;
-  box-shadow: ${({ theme }) => theme.shadows.dark};
+  box-shadow: ${({ theme }) => theme.shadows.main};
 `;
 
 const Title = styled.h2`
   text-align: center;
   margin-bottom: 2rem;
-  color: ${({ theme }) => theme.colors.dark.accent};
+  color: ${({ theme }) => theme.colors.light.text};
   font-size: 2rem;
 `;
 
@@ -58,32 +59,35 @@ const FormGroup = styled.div`
 
 const Label = styled.label`
   font-weight: 500;
-  color: ${({ theme }) => theme.colors.dark.textSecondary};
+  color: ${({ theme }) => theme.colors.light.textMuted};
 `;
 
 const Input = styled.input`
   padding: 0.8rem 1rem;
-  border: 1px solid ${({ theme }) => theme.colors.dark.border};
+  border: 1px solid ${({ theme }) => theme.colors.light.border};
   border-radius: 8px;
-  background-color: ${({ theme }) => theme.colors.dark.background};
-  color: ${({ theme }) => theme.colors.dark.text};
+  background-color: #FFFFFF;
+  color: ${({ theme }) => theme.colors.light.text};
   font-size: 1rem;
 `;
 
 const SubmitButton = styled.button`
   margin-top: 1rem;
   padding: 0.8rem 1rem;
-  background-color: ${({ theme }) => theme.colors.dark.primary};
-  color: white;
-  border: none;
+  background: ${({ theme }) => theme.colors.light.secondary};
+  color: ${({ theme }) => theme.colors.light.text};
+  border: 1px solid ${({ theme }) => theme.colors.light.primary};
+  box-shadow: 2px 2px 0px ${({ theme }) => theme.colors.light.primary};
   border-radius: 8px;
   cursor: pointer;
   font-size: 1rem;
   font-weight: bold;
   opacity: ${props => props.disabled ? 0.5 : 1};
-  
-  &:hover {
-    background-color: ${({ theme }) => theme.colors.dark.primaryHover};
+  transition: all 0.2s ease;
+
+  &:hover:not(:disabled) {
+    box-shadow: 4px 4px 0px ${({ theme }) => theme.colors.light.primary};
+    transform: translate(-2px, -2px);
   }
 `;
 

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -11,6 +11,9 @@ server {
     listen 443 ssl http2;
     server_name suzookaizokuhunter.com;
 
+    # Allow large file uploads
+    client_max_body_size 100M;
+
     ssl_certificate /etc/letsencrypt/live/suzookaizokuhunter.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/suzookaizokuhunter.com/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;
@@ -31,6 +34,16 @@ server {
     # [★★ KEY FIX 2 ★★] Rewrite and forward /auth requests to /api/auth
     location /auth/ {
         rewrite /auth/(.*) /api/auth/$1 break;
+        proxy_pass http://suzoo_express:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Route /protect calls to backend API
+    location /protect/ {
+        rewrite /protect/(.*) /api/protect/$1 break;
         proxy_pass http://suzoo_express:3000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
- allow uploads up to 100MB in nginx
- route `/protect` requests to the API server
- switch ProtectStep1 page to light theme

## Testing
- `pnpm test` *(fails: sharp module missing and express tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_687b2f4c25c083248a5242754daaf0d6