### PR TITLE
Update nginx proxy rules

### DIFF
--- a/frontend/nginx/production.conf
+++ b/frontend/nginx/production.conf
@@ -2,12 +2,10 @@ server {
     listen 80;
     server_name suzookaizokuhunter.com;
 
-    # Let's Encrypt renewal challenge
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;
     }
 
-    # Redirect all other HTTP traffic to HTTPS
     location / {
         return 301 https://$host$request_uri;
     }
@@ -17,51 +15,31 @@ server {
     listen 443 ssl http2;
     server_name suzookaizokuhunter.com;
 
-    # [★★ 關鍵修正 ★★] 允許最大 100MB 的檔案上傳
     client_max_body_size 100M;
 
-    # SSL Certificates
     ssl_certificate /etc/letsencrypt/live/suzookaizokuhunter.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/suzookaizokuhunter.com/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
-    # Root for React static files
     root /usr/share/nginx/html;
     index index.html;
 
-    # --- API Reverse Proxy Rules ---
+    # [★★ KEY FIX ★★] Unified API proxy rules
+    location ~ ^/(api|auth|protect)/ {
+        rewrite ^/auth/(.*)$ /api/auth/$1 last;
+        rewrite ^/protect/(.*)$ /api/protect/$1 last;
 
-    # Forward general API requests
-    location /api/ {
         proxy_pass http://suzoo_express:3000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
     }
 
-    # Rewrite and forward /protect/ requests to the backend API
-    location /protect/ {
-        rewrite /protect/(.*) /api/protect/$1 break;
-        proxy_pass http://suzoo_express:3000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-    # Rewrite and forward /auth/ requests to the backend API
-    location /auth/ {
-        rewrite /auth/(.*) /api/auth/$1 break;
-        proxy_pass http://suzoo_express:3000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-    # Serve React App for all other requests (handles client-side routing)
     location / {
         try_files $uri $uri/ /index.html;
     }


### PR DESCRIPTION
## Summary
- consolidate `/api`, `/auth`, and `/protect` into a single proxy block
- adjust rewrites so Express server receives correct routes

## Testing
- `pnpm install`
- `npm test` *(fails: sharp module missing & other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_687b3b507b0083249795110304e98bd7