### PR TITLE
Fix Nginx API routing and client base URL

### DIFF
--- a/frontend/nginx/production.conf
+++ b/frontend/nginx/production.conf
@@ -25,19 +25,13 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # [★★ KEY FIX ★★] Unified API proxy rules
-    location ~ ^/(api|auth|protect)/ {
-        rewrite ^/auth/(.*)$ /api/auth/$1 last;
-        rewrite ^/protect/(.*)$ /api/protect/$1 last;
-
+    # Proxy ONLY API calls to the backend
+    location /api {
         proxy_pass http://suzoo_express:3000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
     }
 
     location / {

--- a/frontend/src/apiClient.js
+++ b/frontend/src/apiClient.js
@@ -1,75 +1,30 @@
-/**
- * apiClient.js
- * 應用程式的集中式 API 請求模組
- *
- * 功能:
- * 1. 從環境變數中讀取後端 API 的基礎 URL。
- * 2. 自動將 localStorage 中的 token 加入到請求標頭 (headers) 中。
- * 3. 處理 FormData 和 JSON body。
- */
+import axios from 'axios';
 
-/**
- * 從環境變數中讀取後端 API 的基礎 URL，若未設定則使用空字串，
- * 讓呼叫端在開發環境下可以自由指定完整路徑
- */
-const BASE_URL = process.env.REACT_APP_API_URL || '';
+const apiClient = axios.create({
+  // [★★ KEY FIX ★★] Prepend all API calls with /api
+  baseURL: '/api',
+});
 
-/**
- * 執行一個 API 請求
- * @param {string} path - API 的路徑 (例如: '/api/protect/step1')
- * @param {object} options - Fetch API 的選項 (method, body, etc.)
- * @returns {Promise<any>} 解析後的 JSON 回應
- */
-export async function apiRequest(path, options = {}) {
-    const fullUrl = `${BASE_URL}${path}`;
-
-    // 調試日誌
-    if (process.env.NODE_ENV !== 'production') {
-        console.log(`API Request: ${fullUrl}`, options);
-    }
-
-    const headers = {
-        ...(options.body instanceof FormData ? {} : { 'Content-Type': 'application/json' }),
-        ...options.headers,
-    };
-
+// Add a request interceptor to include the token in headers
+apiClient.interceptors.request.use(
+  (config) => {
     const token = localStorage.getItem('token');
     if (token) {
-        headers['Authorization'] = `Bearer ${token}`;
+      config.headers = config.headers || {};
+      config.headers['Authorization'] = `Bearer ${token}`;
     }
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
 
-    try {
-        const response = await fetch(fullUrl, {
-            ...options,
-            headers,
-            body: options.body instanceof FormData ? options.body : JSON.stringify(options.body),
-        });
+// Optional: Add a response interceptor for global error handling
+apiClient.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    const message = error.response?.data?.message || error.message || 'An unexpected error occurred';
+    return Promise.reject(new Error(message));
+  }
+);
 
-        // 處理非JSON響應
-        const contentType = response.headers.get('content-type');
-        let data;
-        if (contentType && contentType.includes('application/json')) {
-            data = await response.json();
-        } else {
-            data = await response.text();
-        }
-
-        if (!response.ok) {
-            const errorMessage = data.message || data.error || `伺服器錯誤: ${response.status}`;
-            throw new Error(errorMessage);
-        }
-
-        return data;
-    } catch (error) {
-        console.error(`API request to ${fullUrl} failed:`, error);
-        throw error;
-    }
-}
-
-// Provide a simple client wrapper for convenience
-export const apiClient = {
-    get: (path, options = {}) => apiRequest(path, { method: 'GET', ...options }),
-    post: (path, body, options = {}) => apiRequest(path, { method: 'POST', body, ...options }),
-    put: (path, body, options = {}) => apiRequest(path, { method: 'PUT', body, ...options }),
-    delete: (path, options = {}) => apiRequest(path, { method: 'DELETE', ...options }),
-};
+export { apiClient };


### PR DESCRIPTION
## Summary
- adjust Nginx production config so only `/api` is proxied to Express
- update frontend apiClient to use axios with `/api` baseURL

## Testing
- `npm install` (root, frontend, express)
- `npm test` *(fails: suzoo-express test suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_687b74862b988324b1c91c169ba01c40