### PR TITLE
Fix scan status API and API key checks

### DIFF
--- a/express/routes/scans.js
+++ b/express/routes/scans.js
@@ -10,8 +10,8 @@ const auth = require('../middleware/auth');
  * Checks the status and result of a specific scan task.
  * This is the primary endpoint for the frontend to poll for scan results.
  */
-router.get('/status/:scanId', async (req, res) => {
-    // [關鍵修正] 將參數從 taskId 改為 scanId，以匹配前端的 API 呼叫
+// 新舊路徑兼容：/status/:scanId 與 /:scanId/status 皆可取得任務狀態
+async function getScanStatus(req, res) {
     const { scanId } = req.params;
 
     if (!scanId) {
@@ -54,7 +54,10 @@ router.get('/status/:scanId', async (req, res) => {
         logger.error(`[Scan Status API] Failed to get status for task ID ${scanId}:`, error);
         res.status(500).json({ error: 'Failed to retrieve scan status.' });
     }
-});
+}
+
+router.get('/status/:scanId', getScanStatus);
+router.get('/:scanId/status', getScanStatus);
 
 
 /**

--- a/express/services/bing.service.js
+++ b/express/services/bing.service.js
@@ -3,13 +3,17 @@ const axios = require('axios');
 const FormData = require('form-data');
 const logger = require('../utils/logger');
 
-const BING_API_KEY = process.env.BING_API_KEY;
+const BING_API_KEY = process.env.BING_API_KEY ? process.env.BING_API_KEY.trim() : '';
 const BING_ENDPOINT = process.env.BING_ENDPOINT;
 
 async function searchByBuffer(buffer) {
   if (!BING_API_KEY || !BING_ENDPOINT) {
     logger.warn('[Bing Service] BING_API_KEY or BING_ENDPOINT is not configured. Service disabled.');
     return { success: false, links: [], error: 'Bing API key or endpoint not configured.' };
+  }
+  if (!/^[A-Fa-f0-9]{32}$/.test(BING_API_KEY)) {
+    logger.error('[Bing Service] Invalid API key format.');
+    return { success: false, links: [], error: 'Invalid Bing API key format.' };
   }
   if (!buffer) {
     return { success: false, links: [], error: 'Invalid image buffer provided.' };


### PR DESCRIPTION
## Summary
- add function `getScanStatus` and expose `/scans/:scanId/status` route for frontend polling
- validate and trim API keys for Bing and RapidAPI services
- disable RapidAPI platforms on 403 errors

## Testing
- `npm install` *(install dependencies)*
- `npm test` *(fails: suzoo-express test suite errors)*


------
https://chatgpt.com/codex/tasks/task_e_687bee81329883248e45b8fb1fad7622