### PR TITLE
Improve express startup reliability

### DIFF
--- a/express/server.js
+++ b/express/server.js
@@ -53,14 +53,34 @@ app.get('/health', (req, res) => {
 const PORT = process.env.EXPRESS_PORT || 3000;
 
 async function startServer() {
+    const MAX_RETRIES = parseInt(process.env.DB_CONN_RETRIES || '5', 10);
+    const RETRY_DELAY = parseInt(process.env.DB_CONN_RETRY_DELAY_MS || '3000', 10);
+
     try {
         logger.info('[Startup] Connecting to database...');
-        await db.sequelize.authenticate();
-        logger.info('[Database] Connection established.');
+
+        let connected = false;
+        for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+            try {
+                await db.sequelize.authenticate();
+                connected = true;
+                logger.info('[Database] Connection established.');
+                break;
+            } catch (err) {
+                logger.warn(`[Database] Connection attempt ${attempt}/${MAX_RETRIES} failed: ${err.message}`);
+                if (attempt < MAX_RETRIES) {
+                    await new Promise(res => setTimeout(res, RETRY_DELAY));
+                }
+            }
+        }
+
+        if (!connected) {
+            throw new Error('Database connection failed after all retries');
+        }
 
         await db.sequelize.sync({ alter: true });
         logger.info('[Database] Models synchronized.');
-        
+
         server.listen(PORT, '0.0.0.0', () => {
             logger.info(`[Express] Server is ready and running on http://0.0.0.0:${PORT}`);
         });
@@ -71,4 +91,16 @@ async function startServer() {
     }
 }
 
-startServer();
+process.on('unhandledRejection', (reason, promise) => {
+    logger.error('Unhandled Rejection at:', promise, 'reason:', reason);
+});
+
+process.on('uncaughtException', (err) => {
+    logger.error('Uncaught Exception:', err);
+    process.exit(1);
+});
+
+startServer().catch((error) => {
+    logger.error('Asynchronous error in startServer:', error);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add database connection retry logic in express server
- add global error handlers for unhandled promise rejections and uncaught exceptions

## Testing
- `npm test` *(fails: turbo build exited with error)*

------
https://chatgpt.com/codex/tasks/task_e_687df2887a84832489c3e5648d422f68