### PR TITLE
Update accordion text color to dark orange

### DIFF
--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -158,7 +158,8 @@ const AccordionContent = styled.div`
   padding: 0 1rem 1rem 1rem;
   font-size: 0.95rem;
   line-height: 1.7;
-  color: #555;
+  /* [★★ UI UPDATE ★★] Change text color to dark orange */
+  color: #FF8C00;
   p strong {
       color: #D45398;
   }


### PR DESCRIPTION
## Summary
- make accordion content text dark orange for improved style

## Testing
- `pnpm test` *(fails: suzoo-express test suite)*

------
https://chatgpt.com/codex/tasks/task_e_687dfda4d6ac83249cd00c671c78da50