### PR TITLE
Fix IPFS initialization

### DIFF
--- a/express/server.js
+++ b/express/server.js
@@ -26,7 +26,7 @@ const adminRoutes = require('./routes/admin');
 const dashboardRoutes = require('./routes/dashboard');
 
 // Services
-const { init: initIpfs } = require('./services/ipfsService');
+const ipfsService = require('./services/ipfsService');
 
 // App & server initialization
 const app = express();
@@ -72,7 +72,7 @@ async function startServer() {
 
         // 1. Initialize IPFS service with limited retries
         try {
-            await initIpfs();
+            await ipfsService.init();
             logger.info('[ipfsService] IPFS initialized successfully');
         } catch (ipfsError) {
             logger.error('[ipfsService] IPFS initialization failed, proceeding without IPFS:', ipfsError);


### PR DESCRIPTION
## Summary
- ensure ipfsService's init runs with correct context

## Testing
- `npm install` in `express`
- `npm test` in `express` *(fails: GET /api/users/:id etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687e070f5f0c8324877340908c5e4ea8