### PR TITLE
Fix upload & proof generation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - IPFS_API_URL=http://suzoo_ipfs:5001
       - DB_CONN_RETRIES=10
       - DB_CONN_RETRY_DELAY_MS=5000
+      - MAX_FILE_SIZE=104857600 # 100MB
     volumes:
       - ./express:/app
       - /app/node_modules # 保持匿名 volume 以隔離主機的 node_modules


### PR DESCRIPTION
## Summary
- enable multer in protect routes and add a `/generate-proof` endpoint
- improve IPFS client with timeouts and stable add/cat methods
- update FileUpload component to validate file size and use auth token
- expose DB and IPFS state via enhanced `/health` route
- limit upload size via docker-compose

## Testing
- `pnpm test` *(fails: Test Suites: 3 failed)*
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_687e21d1094883248f84e9366841cfc4