### PR TITLE
Implement async scan dispatch workflow

### DIFF
--- a/express/routes/scans.js
+++ b/express/routes/scans.js
@@ -4,6 +4,7 @@ const router = express.Router();
 const db = require('../models');
 const logger = require('../utils/logger');
 const auth = require('../middleware/auth');
+const queueService = require('../services/queue.service');
 
 /**
  * GET /api/scans/status/:scanId

--- a/express/server.js
+++ b/express/server.js
@@ -23,6 +23,7 @@ const protectRoutes = require('./routes/protect');
 const authRoutes = require('./routes/authRoutes');
 const adminRoutes = require('./routes/admin');
 const dashboardRoutes = require('./routes/dashboard');
+const scansRoutes = require('./routes/scans'); // ★ 導入新的 scans 路由
 
 // Services
 const ipfsService = require('./services/ipfsService');
@@ -47,6 +48,7 @@ app.use('/api/protect', protectRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/admin', adminRoutes);
 app.use('/api/dashboard', dashboardRoutes);
+app.use('/api/scans', scansRoutes); // ★ 掛載新的 scans 路由
 
 // ★ 新增區塊鏈專用健康檢查端點 ★
 app.get('/blockchain-health', async (req, res) => {


### PR DESCRIPTION
## Summary
- update ProtectStep2 to dispatch asynchronous scan task and redirect to progress page
- mount `/api/scans` endpoint in express server
- import queue service for scans routes
- replace synchronous scan in protect routes with async task dispatch

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e50e928548324b3fc6640e88b1759