### PR TITLE
Add free trial funnel and pricing updates

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,7 @@ import AppLayout from './layouts/AppLayout';
 // Pages
 import HomePage from './pages/HomePage';
 import PricingPage from './pages/PricingPage';
+import FreeTrialLandingPage from './pages/FreeTrialLandingPage';
 import ContactPage from './pages/ContactPage';
 import AboutPage from './pages/AboutPage';
 import BlogPostPage from './pages/BlogPostPage';
@@ -72,6 +73,7 @@ function App() {
                 <Route path="/about" element={<AboutPage />} />
                 <Route path="/blog/post-1" element={<BlogPostPage />} />
                 <Route path="/payment" element={<PaymentPage />} />
+                <Route path="/free-trial" element={<FreeTrialLandingPage />} />
                 <Route path="/protect/step1" element={<ProtectStep1 />} />
                 <Route path="/protect/step2" element={<ProtectStep2 />} />
                 <Route path="/protect/step3" element={<ProtectStep3 />} />

--- a/frontend/src/components/ExperienceCompleteModal.jsx
+++ b/frontend/src/components/ExperienceCompleteModal.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
 
 const Overlay = styled.div`
   position: fixed;
@@ -110,6 +111,7 @@ const PlanButton = styled.button`
 `;
 
 export default function ExperienceCompleteModal({ onClose }) {
+  const navigate = useNavigate();
   return (
     <Overlay>
       <ModalContent>
@@ -118,43 +120,26 @@ export default function ExperienceCompleteModal({ onClose }) {
         <p>您已成功體驗我們的著作權保護服務，升級專業版解鎖完整功能：</p>
         <PlanGrid>
           <PlanCard>
-            <PlanTitle>基礎版</PlanTitle>
-            <PlanPrice>NT$600<span>/月</span></PlanPrice>
+            <PlanTitle>CREATOR</PlanTitle>
+            <PlanPrice>NT$390<span>/月</span></PlanPrice>
             <FeatureList>
-              <li>每月 50 次圖片偵測</li>
-              <li>每月 10 次影片偵測</li>
-              <li>基本侵權報告</li>
-              <li>5GB IPFS 儲存空間</li>
-              <li>標準客服支援</li>
+              <li><strong>100</strong> 件作品存證</li>
+              <li>每月 <strong>10</strong> 次 AI 掃描</li>
+              <li><strong>完整侵權報告</strong></li>
+              <li>每月 <strong>1</strong> 次 DMCA 下架</li>
             </FeatureList>
-            <PlanButton>選擇此方案</PlanButton>
+            <PlanButton onClick={() => navigate('/pricing')}>選擇此方案</PlanButton>
           </PlanCard>
           <PlanCard featured>
-            <div style={{
-              position: 'absolute',
-              top: '-12px',
-              left: '50%',
-              transform: 'translateX(-50%)',
-              background: '#4285f4',
-              color: 'white',
-              padding: '4px 12px',
-              borderRadius: '20px',
-              fontSize: '0.8rem'
-            }}>
-              最受歡迎
-            </div>
-            <PlanTitle featured>專業版</PlanTitle>
-            <PlanPrice featured>NT$1,200<span>/月</span></PlanPrice>
-            <FeatureList featured>
-              <li>無限圖片/影片偵測</li>
-              <li>商標偵測功能</li>
-              <li>詳細侵權報告</li>
-              <li>一鍵DMCA下架</li>
-              <li>法律諮詢服務</li>
-              <li>20GB IPFS 儲存空間</li>
-              <li>優先客服支援</li>
+            <PlanTitle featured>PROFESSIONAL</PlanTitle>
+            <PlanPrice featured>NT$1,490<span>/月</span></PlanPrice>
+            <FeatureList>
+              <li><strong>500</strong> 件作品存證</li>
+              <li>每月 <strong>50</strong> 次 AI 掃描</li>
+              <li><strong>批量處理工具</strong></li>
+              <li>每月 <strong>5</strong> 次 DMCA 下架</li>
             </FeatureList>
-            <PlanButton featured>立即升級</PlanButton>
+            <PlanButton featured onClick={() => navigate('/pricing')}>立即升級</PlanButton>
           </PlanCard>
         </PlanGrid>
         <div style={{ marginTop: '1.5rem' }}>

--- a/frontend/src/pages/FreeTrialLandingPage.jsx
+++ b/frontend/src/pages/FreeTrialLandingPage.jsx
@@ -1,0 +1,133 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+
+const PageWrapper = styled.div`
+  background: linear-gradient(135deg, #1a2a6c, #b21f1f, #fdbb2d);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  color: white;
+`;
+
+const Card = styled.div`
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  border-radius: 20px;
+  padding: 2.5rem;
+  width: 100%;
+  max-width: 600px;
+  box-shadow: 0 8px 32px 0 rgba(31, 38, 135, 0.37);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+`;
+
+const StepsContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin: 2rem 0;
+  gap: 1rem;
+`;
+
+const Step = styled.div`
+  text-align: center;
+  flex: 1;
+  .number {
+    background: white;
+    color: #1a2a6c;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto 1rem;
+    font-weight: bold;
+    font-size: 1.2rem;
+  }
+`;
+
+const TrialForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+const Input = styled.input`
+  width: 100%;
+  padding: 0.8rem 1rem;
+  border-radius: 8px;
+  border: 1px solid rgba(255,255,255,0.5);
+  background: rgba(255,255,255,0.2);
+  color: white;
+  font-size: 1rem;
+  &::placeholder { color: rgba(255,255,255,0.7); }
+`;
+
+const SubmitButton = styled.button`
+  padding: 0.8rem 1rem;
+  border-radius: 8px;
+  border: none;
+  background: #EBB0CF;
+  color: #0A0101;
+  font-weight: bold;
+  font-size: 1.1rem;
+  cursor: pointer;
+  margin-top: 1rem;
+`;
+
+const FreeTrialLandingPage = () => {
+  const navigate = useNavigate();
+  const [realName, setRealName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    localStorage.setItem('trial_realName', realName);
+    localStorage.setItem('trial_email', email);
+    localStorage.setItem('trial_phone', phone);
+    navigate('/protect/step1');
+  };
+
+  return (
+    <PageWrapper>
+      <h1>免費體驗，即刻感受王者級保護</h1>
+      <p>體驗強大的區塊鏈存證與 AI 侵權偵測系統</p>
+      <Card>
+        <h2>只需三步驟，為您的創作賦權</h2>
+        <StepsContainer>
+          <Step>
+            <div className="number">1</div>
+            <h3>上傳作品</h3>
+            <p>圖片 / 影片</p>
+          </Step>
+          <Step>
+            <div className="number">2</div>
+            <h3>生成權威證據</h3>
+            <p>IPFS + 區塊鏈</p>
+          </Step>
+          <Step>
+            <div className="number">3</div>
+            <h3>獲取侵權摘要</h3>
+            <p>AI 全網掃描</p>
+          </Step>
+        </StepsContainer>
+        <TrialForm onSubmit={handleSubmit}>
+          <h3>填寫資料，立即開始</h3>
+          <Input type="text" value={realName} onChange={(e) => setRealName(e.target.value)} placeholder="您的姓名或品牌名稱" required />
+          <Input type="email" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="您的電子郵件" required />
+          <Input type="tel" value={phone} onChange={(e) => setPhone(e.target.value)} placeholder="您的手機號碼" required />
+          <SubmitButton type="submit">開始免費體驗</SubmitButton>
+          <p style={{fontSize: '0.8rem', textAlign: 'center', opacity: 0.7}}>
+            點擊即表示您同意我們的服務條款。體驗後將收到完整功能解鎖方案。
+          </p>
+        </TrialForm>
+      </Card>
+    </PageWrapper>
+  );
+};
+
+export default FreeTrialLandingPage;

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -193,7 +193,7 @@ const HomePage = () => {
           <p style={{ maxWidth: '700px', lineHeight: '1.6', fontSize: '1.1rem' }}>
             <strong>ONLY WE</strong> combine unstoppable <strong>Blockchain Fingerprinting</strong> with advanced <strong>AI Infringement Detection</strong> and global legal solutions, recognized under the <strong>Berne Convention</strong> and <strong>WTO/TRIPS</strong>.
           </p>
-          <PrimaryButton to="/protect/step1">立即免費體驗</PrimaryButton>
+          <PrimaryButton to="/free-trial">立即免費體驗</PrimaryButton>
         </HeroContainer>
       </HeroWrapper>
 

--- a/frontend/src/pages/PricingPage.jsx
+++ b/frontend/src/pages/PricingPage.jsx
@@ -148,47 +148,47 @@ const PricingPage = () => {
               年繳方案享有 2 個月免費優惠，是您最划算的選擇。
             </SectionDescription>
             <PricingGrid>
-              {/* --- Free Plan --- */}
+              {/* Free Plan */}
               <Card>
-                <PlanName>FREE</PlanName>
+                <PlanName>FREE (永久免費版)</PlanName>
                 <PlanPrice>NT$0</PlanPrice>
                 <FeatureList>
-                  <FeatureItem><strong>5</strong> 件作品永久區塊鏈存證</FeatureItem>
-                  <FeatureItem>每月 <strong>1</strong> 次免費 AI 掃描</FeatureItem>
+                  <FeatureItem><strong>5</strong> 件作品永久存證席位</FeatureItem>
+                  <FeatureItem>每月 <strong>1</strong> 次 AI 掃描額度</FeatureItem>
                   <FeatureItem>掃描結果摘要報告</FeatureItem>
-                  <FeatureItem>✓ 無限次證書下載</FeatureItem>
+                  <FeatureItem>無限次證書下載</FeatureItem>
                 </FeatureList>
-                <PlanRemark>適合剛起步，想體驗核心功能的您</PlanRemark>
                 <StyledButton to="/register">免費註冊</StyledButton>
               </Card>
 
-              {/* --- Creator Plan --- */}
+              {/* Creator Plan */}
               <Card>
-                <PlanName>CREATOR</PlanName>
+                <PlanName>CREATOR (守護者方案)</PlanName>
                 <PlanPrice>NT$390 / 月</PlanPrice>
                 <FeatureList>
-                  <FeatureItem><strong>100</strong> 件作品永久區塊鏈存證</FeatureItem>
-                  <FeatureItem>每月 <strong>10</strong> 次 AI 掃描</FeatureItem>
-                  <FeatureItem><strong>解鎖完整侵權報告</strong></FeatureItem>
-                  <FeatureItem>每月 <strong>1</strong> 次免費 DMCA 下架</FeatureItem>
+                  <FeatureItem><strong>100</strong> 件作品永久存證席位</FeatureItem>
+                  <FeatureItem>每月 <strong>10</strong> 次 AI 掃描額度</FeatureItem>
+                  <FeatureItem>每週自動巡檢</FeatureItem>
+                  <FeatureItem>每月 <strong>1</strong> 次 DMCA 下架額度</FeatureItem>
+                  <FeatureItem>解鎖完整侵權報告</FeatureItem>
                 </FeatureList>
-                <PlanRemark>適合個人創作者、攝影師、部落客</PlanRemark>
                 <StyledButton as="button" onClick={() => handleChoosePlan('CREATOR', 390)} primary>
                   選擇 Creator
                 </StyledButton>
               </Card>
-              {/* --- Professional Plan --- */}
+              {/* Professional Plan */}
               <Card>
-                <PlanName>PROFESSIONAL</PlanName>
+                <PlanName>PROFESSIONAL (捍衛者方案)</PlanName>
                 <PlanPrice>NT$1,490 / 月</PlanPrice>
                 <FeatureList>
-                  <FeatureItem><strong>500</strong> 件作品永久區塊鏈存證</FeatureItem>
-                  <FeatureItem>每月 <strong>50</strong> 次 AI 掃描</FeatureItem>
-                  <FeatureItem><strong>批量上傳 & 批量掃描</strong></FeatureItem>
-                  <FeatureItem>每月 <strong>5</strong> 次免費 DMCA 下架</FeatureItem>
-                  <FeatureItem>Email 法律諮詢支援</FeatureItem>
+                  <FeatureItem><strong>500</strong> 件作品永久存證席位</FeatureItem>
+                  <FeatureItem>每月 <strong>50</strong> 次 AI 掃描額度</FeatureItem>
+                  <FeatureItem><strong>每日優先掃描</strong></FeatureItem>
+                  <FeatureItem>每月 <strong>5</strong> 次 DMCA 下架額度</FeatureItem>
+                  <FeatureItem><strong>批量處理工具</strong></FeatureItem>
+                  <FeatureItem><strong>商標監測功能</strong></FeatureItem>
+                  <FeatureItem>Email 法律諮詢</FeatureItem>
                 </FeatureList>
-                <PlanRemark>適合專業工作室、設計師、YouTuber</PlanRemark>
                 <StyledButton as="button" onClick={() => handleChoosePlan('PROFESSIONAL', 1490)} primary>
                   選擇 Professional
                 </StyledButton>

--- a/frontend/src/pages/ProtectStep1.jsx
+++ b/frontend/src/pages/ProtectStep1.jsx
@@ -100,9 +100,9 @@ const ProtectStep1 = () => {
   const navigate = useNavigate();
   const [file, setFile] = useState(null);
   const [title, setTitle] = useState('');
-  const [realName, setRealName] = useState(localStorage.getItem('trial_realName') || '');
-  const [email, setEmail] = useState(localStorage.getItem('trial_email') || '');
-  const [phone, setPhone] = useState(localStorage.getItem('trial_phone') || '');
+  const [realName, setRealName] = useState(() => localStorage.getItem('trial_realName') || '');
+  const [email, setEmail] = useState(() => localStorage.getItem('trial_email') || '');
+  const [phone, setPhone] = useState(() => localStorage.getItem('trial_phone') || '');
   const [keywords, setKeywords] = useState('');
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);

--- a/frontend/src/pages/ProtectStep4.jsx
+++ b/frontend/src/pages/ProtectStep4.jsx
@@ -198,7 +198,12 @@ export default function ProtectStep4() {
       sources: Object.keys(scanResults.results || {}).length
     });
 
-  }, [scanResults, fileInfo, navigate]);
+    if (!user) {
+      const timer = setTimeout(() => setShowUpgradeModal(true), 1500);
+      return () => clearTimeout(timer);
+    }
+
+  }, [scanResults, fileInfo, navigate, user]);
 
   const handleTakedown = async url => {
     if (takedownStatus[url] && takedownStatus[url].status !== 'error') return;


### PR DESCRIPTION
## Summary
- route home trial button to new landing page
- implement `FreeTrialLandingPage` for onboarding
- preload trial info in ProtectStep1
- auto-show upgrade modal in ProtectStep4
- update upgrade modal links
- refresh PricingPage plans
- register `/free-trial` route

## Testing
- `pnpm lint`
- `pnpm test` *(fails: 5 failing tests)*
- `docker compose up -d --build` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687fa7b7a3b48324a3fe0d7dc0ea826f