### PR TITLE
Add manual payment workflow and pricing page updates

### DIFF
--- a/express/routes/admin.js
+++ b/express/routes/admin.js
@@ -170,11 +170,14 @@ router.post('/approve-payment/:proofId', async (req, res) => {
  expires_at: expiresAt
  }, { transaction });
 
- await proof.update({ status: 'approved', approved_by: req.user.id }, { transaction });
+    await proof.update({ status: 'approved', approved_by: req.user.id }, { transaction });
 
- await transaction.commit();
+    await transaction.commit();
 
- res.json({ message: `已成功為 ${user.email} 開通 ${plan.name} 方案` });
+    // TODO: 在此處整合 Email 服務，通知使用者方案已開通
+    // await emailService.sendSubscriptionActivatedEmail(user.email, plan.name);
+
+    res.json({ message: `已成功為 ${user.email} 開通 ${plan.name} 方案` });
 
  } catch (err) {
  await transaction.rollback();

--- a/express/routes/payments.js
+++ b/express/routes/payments.js
@@ -20,8 +20,11 @@ router.post('/submit-proof', auth, async (req, res) => {
             account_last_five: accountLastFive,
             user_email: userEmail,
             notes: notes,
-            status: 'pending'
+            status: 'pending' // 狀態為待審核
         });
+
+        // TODO: 在此處整合 Email 服務，發送確認信給使用者
+        // await emailService.sendPaymentProofReceivedEmail(userEmail);
 
         logger.info(`[Payment] Received payment proof from User ID: ${userId} for plan ${planCode}`);
         res.status(201).json({ message: '已成功收到您的付款證明，我們將在 1 個工作小時內完成審核並為您開通權限。' });

--- a/frontend/src/pages/PricingPage.jsx
+++ b/frontend/src/pages/PricingPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 const PageSpacer = styled.div` min-height: 74px; `;
 const PageWrapper = styled.div` padding: 4rem 2rem; background-color: #f9fafb; `;
@@ -8,37 +8,34 @@ const ContentContainer = styled.div` max-width: 1200px; margin: 0 auto; text-ali
 const Header = styled.header` margin-bottom: 4rem; `;
 const Title = styled.h1` font-size: 3rem; font-weight: 800; margin-bottom: 1rem; `;
 const Subtitle = styled.p` font-size: 1.25rem; color: #6b7280; max-width: 700px; margin: 0 auto; line-height: 1.6; `;
+const Section = styled.section` margin-bottom: 3rem; `;
+const SectionTitle = styled.h2` font-size: 2rem; font-weight: 700; margin-bottom: 1rem; `;
+const SectionDescription = styled.p` font-size: 1rem; color: #6b7280; margin-bottom: 2rem; `;
 const PricingGrid = styled.div` display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 2rem; align-items: stretch; @media(max-width: 992px) { grid-template-columns: 1fr; }`;
 const Card = styled.div`
   background: white;
-  border: 2px solid ${({ featured }) => (featured ? '#D45398' : '#E5E7EB')};
+  border: 2px solid #E5E7EB;
   border-radius: 12px; padding: 2rem; display: flex; flex-direction: column; text-align: left;
   box-shadow: 0 4px 6px rgba(0,0,0,0.05);
-  transform: ${({ featured }) => (featured ? 'scale(1.05)' : 'scale(1)')};
-  transition: all 0.3s ease; position: relative;
-  &:hover { transform: translateY(-10px) ${({ featured }) => (featured ? 'scale(1.05)' : 'scale(1.02)')}; }
 `;
 const PlanName = styled.h3` font-size: 1.5rem; font-weight: 700; color: #111827; `;
-const PlanPrice = styled.p` font-size: 2.5rem; font-weight: 800; margin: 0.5rem 0; span { font-size: 1rem; color: #6b7280; font-weight: 400; }`;
+const PlanPrice = styled.p` font-size: 2.5rem; font-weight: 800; margin: 0.5rem 0; `;
 const FeatureList = styled.ul` list-style: '✓'; padding-left: 1.5rem; flex-grow: 1; margin: 2rem 0; `;
 const FeatureItem = styled.li` margin-bottom: 1rem; color: #374151; `;
-const StyledButton = styled.button`
+const PlanRemark = styled.p` margin-top: auto; color: #6b7280; font-size: 0.9rem; `;
+const StyledButton = styled(Link)`
   display: block; width: 100%; text-align: center; text-decoration: none;
-  font-weight: 600; padding: 14px 28px; border-radius: 12px; margin-top: auto;
-  border: none;
-  background: ${({ featured }) => (featured ? '#D45398' : '#A855F7')};
-  color: #FFFFFF; cursor: pointer; transition: all 0.2s ease;
+  font-weight: 600; padding: 14px 28px; border-radius: 12px; margin-top: 1rem;
+  background: #A855F7; color: #FFFFFF; cursor: pointer; transition: all 0.2s ease;
   &:hover { opacity: 0.9; transform: scale(1.02); }
-`;
-const PopularBadge = styled.div`
-  position: absolute; top: -15px; left: 50%; transform: translateX(-50%);
-  background: #D45398; color: white; padding: 5px 15px; border-radius: 20px;
-  font-size: 0.8rem; font-weight: bold;
 `;
 
 const PricingPage = () => {
   const navigate = useNavigate();
-  const handleChoosePlan = (planCode, price) => navigate(`/payment?plan=${planCode}&price=${price}`);
+
+  const handleChoosePlan = (planCode, price) => {
+    navigate(`/payment?plan=${planCode}&price=${price}`);
+  };
 
   return (
     <>
@@ -46,54 +43,70 @@ const PricingPage = () => {
       <PageWrapper>
         <ContentContainer>
           <Header>
-            <Title>選擇您的專屬保護方案</Title>
-            <Subtitle>您購買的不僅是服務，更是永久的數位資產權。年繳方案僅需支付 10 個月費用，立即享有折扣。</Subtitle>
+            <Title>方案與定價</Title>
+            <Subtitle>
+              選擇最適合您的方案。所有方案皆包含我們獨家的<strong>區塊鏈 + AI 侵權偵測</strong>核心技術。
+            </Subtitle>
           </Header>
-          <PricingGrid>
-            <Card>
-              <PlanName>CREATOR<br/>守護者方案</PlanName>
-              <PlanPrice>NT$ 390<span> / 月</span></PlanPrice>
-              <FeatureList>
-                <FeatureItem><strong>100</strong> 件作品永久存證席位</FeatureItem>
-                <FeatureItem>每月 <strong>10</strong> 次 AI 掃描額度</FeatureItem>
-                <FeatureItem>每週自動巡檢</FeatureItem>
-                <FeatureItem>每月 <strong>1</strong> 次 DMCA 下架額度</FeatureItem>
-                <FeatureItem>✓ 完整侵權報告</FeatureItem>
-              </FeatureList>
-              <StyledButton onClick={() => handleChoosePlan('CREATOR', 390)}>選擇此方案</StyledButton>
-            </Card>
-            <Card>
-              <PlanName>CREATOR+<br/>進階守護者 (誘餌)</PlanName>
-              <PlanPrice>NT$ 990<span> / 月</span></PlanPrice>
-              <FeatureList>
-                <FeatureItem><strong>300</strong> 件作品永久存證席位</FeatureItem>
-                <FeatureItem>每月 <strong>30</strong> 次 AI 掃描額度</FeatureItem>
-                <FeatureItem>每週自動巡檢</FeatureItem>
-                <FeatureItem>每月 <strong>3</strong> 次 DMCA 下架額度</FeatureItem>
-                <FeatureItem>✓ 完整侵權報告</FeatureItem>
-              </FeatureList>
-              <StyledButton onClick={() => handleChoosePlan('CREATOR_PLUS', 990)}>選擇此方案</StyledButton>
-            </Card>
-            <Card featured>
-              <PopularBadge>最受歡迎</PopularBadge>
-              <PlanName>PROFESSIONAL<br/>捍衛者方案</PlanName>
-              <PlanPrice>NT$ 1,490<span> / 月</span></PlanPrice>
-              <FeatureList>
-                <FeatureItem><strong>500</strong> 件作品永久存證席位</FeatureItem>
-                <FeatureItem>每月 <strong>50</strong> 次 AI 掃描額度</FeatureItem>
-                <FeatureItem><strong>每日優先掃描</strong></FeatureItem>
-                <FeatureItem>每月 <strong>5</strong> 次 DMCA 下架額度</FeatureItem>
-                <FeatureItem>✓ **啟動 P2P 變現引擎**</FeatureItem>
-                <FeatureItem>✓ 批量處理工具</FeatureItem>
-                <FeatureItem>✓ 商標監測功能</FeatureItem>
-                <FeatureItem>✓ Email 法律諮詢</FeatureItem>
-              </FeatureList>
-              <StyledButton featured onClick={() => handleChoosePlan('PROFESSIONAL', 1490)}>升級捍衛者方案</StyledButton>
-            </Card>
-          </PricingGrid>
+
+          <Section>
+            <SectionTitle>訂閱方案</SectionTitle>
+            <SectionDescription>
+              年繳方案享有 2 個月免費優惠，是您最划算的選擇。
+            </SectionDescription>
+            <PricingGrid>
+              {/* --- Free Plan --- */}
+              <Card>
+                <PlanName>FREE</PlanName>
+                <PlanPrice>NT$0</PlanPrice>
+                <FeatureList>
+                  <FeatureItem><strong>5</strong> 件作品永久區塊鏈存證</FeatureItem>
+                  <FeatureItem>每月 <strong>1</strong> 次免費 AI 掃描</FeatureItem>
+                  <FeatureItem>掃描結果摘要報告</FeatureItem>
+                  <FeatureItem>✓ 無限次證書下載</FeatureItem>
+                </FeatureList>
+                <PlanRemark>適合剛起步，想體驗核心功能的您</PlanRemark>
+                <StyledButton to="/register">免費註冊</StyledButton>
+              </Card>
+
+              {/* --- Creator Plan --- */}
+              <Card>
+                <PlanName>CREATOR</PlanName>
+                <PlanPrice>NT$390 / 月</PlanPrice>
+                <FeatureList>
+                  <FeatureItem><strong>100</strong> 件作品永久區塊鏈存證</FeatureItem>
+                  <FeatureItem>每月 <strong>10</strong> 次 AI 掃描</FeatureItem>
+                  <FeatureItem><strong>解鎖完整侵權報告</strong></FeatureItem>
+                  <FeatureItem>每月 <strong>1</strong> 次免費 DMCA 下架</FeatureItem>
+                </FeatureList>
+                <PlanRemark>適合個人創作者、攝影師、部落客</PlanRemark>
+                <StyledButton as="button" onClick={() => handleChoosePlan('CREATOR', 390)} primary>
+                  選擇 Creator
+                </StyledButton>
+              </Card>
+
+              {/* --- Professional Plan --- */}
+              <Card>
+                <PlanName>PROFESSIONAL</PlanName>
+                <PlanPrice>NT$1,490 / 月</PlanPrice>
+                <FeatureList>
+                  <FeatureItem><strong>500</strong> 件作品永久區塊鏈存證</FeatureItem>
+                  <FeatureItem>每月 <strong>50</strong> 次 AI 掃描</FeatureItem>
+                  <FeatureItem><strong>批量上傳 & 批量掃描</strong></FeatureItem>
+                  <FeatureItem>每月 <strong>5</strong> 次免費 DMCA 下架</FeatureItem>
+                  <FeatureItem>Email 法律諮詢支援</FeatureItem>
+                </FeatureList>
+                <PlanRemark>適合專業工作室、設計師、YouTuber</PlanRemark>
+                <StyledButton as="button" onClick={() => handleChoosePlan('PROFESSIONAL', 1490)} primary>
+                  選擇 Professional
+                </StyledButton>
+              </Card>
+            </PricingGrid>
+          </Section>
         </ContentContainer>
       </PageWrapper>
     </>
   );
 };
+
 export default PricingPage;


### PR DESCRIPTION
## Summary
- update pricing page with new plans and redirect to payment form
- note email TODOs in manual payment APIs

## Testing
- `pnpm lint`
- `pnpm test` *(fails: GET /api/users/:id returns 401 instead of expected, vision test file missing)*

------
https://chatgpt.com/codex/tasks/task_e_687fc76192a4832497d4bc003b55b837