### PR TITLE
Implement strategic pricing and home updates

### DIFF
--- a/express/models/subscriptionplan.js
+++ b/express/models/subscriptionplan.js
@@ -16,13 +16,10 @@ module.exports = (sequelize, DataTypes) => {
     name: { type: DataTypes.STRING, allowNull: false },
     monthly_price: DataTypes.DECIMAL(10, 2),
     annual_price: DataTypes.DECIMAL(10, 2),
-    
-    // 最終確定的清晰欄位定義
-    works_quota: { type: DataTypes.INTEGER }, // "作品存證" 總額度
-    scan_quota_monthly: { type: DataTypes.INTEGER }, // 每月 "AI 掃描" 額度
-    dmca_quota_monthly: { type: DataTypes.INTEGER }, // 每月 "DMCA 下架" 額度
-
-    scan_frequency: { type: DataTypes.STRING }, // e.g., 'manual', 'weekly', 'daily'
+    works_quota: { type: DataTypes.INTEGER },
+    scan_quota_monthly: { type: DataTypes.INTEGER },
+    dmca_quota_monthly: { type: DataTypes.INTEGER },
+    scan_frequency: { type: DataTypes.STRING }, // 'manual', 'weekly', 'daily'
     has_batch_processing: { type: DataTypes.BOOLEAN, defaultValue: false },
     has_trademark_monitoring: { type: DataTypes.BOOLEAN, defaultValue: false },
     has_p2p_engine: { type: DataTypes.BOOLEAN, defaultValue: false },

--- a/express/seeders/20250723070000-strategic-subscription-plans.js
+++ b/express/seeders/20250723070000-strategic-subscription-plans.js
@@ -1,0 +1,37 @@
+'use strict';
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    const plans = [
+      {
+        plan_code: 'FREE', name: '永久免費版', monthly_price: 0, annual_price: 0,
+        works_quota: 5, scan_quota_monthly: 1, dmca_quota_monthly: 0,
+        scan_frequency: 'manual', has_batch_processing: false, has_trademark_monitoring: false, has_p2p_engine: false, has_legal_consultation: false,
+        createdAt: new Date(), updatedAt: new Date()
+      },
+      {
+        plan_code: 'CREATOR', name: '守護者方案', monthly_price: 390, annual_price: 3900,
+        works_quota: 100, scan_quota_monthly: 10, dmca_quota_monthly: 1,
+        scan_frequency: 'weekly', has_batch_processing: false, has_trademark_monitoring: false, has_p2p_engine: true, has_legal_consultation: false,
+        createdAt: new Date(), updatedAt: new Date()
+      },
+      {
+        plan_code: 'CREATOR_PLUS', name: '進階守護者', monthly_price: 990, annual_price: 9900,
+        works_quota: 300, scan_quota_monthly: 30, dmca_quota_monthly: 3,
+        scan_frequency: 'weekly', has_batch_processing: false, has_trademark_monitoring: false, has_p2p_engine: true, has_legal_consultation: false,
+        createdAt: new Date(), updatedAt: new Date()
+      },
+      {
+        plan_code: 'PROFESSIONAL', name: '捍衛者方案', monthly_price: 1490, annual_price: 14900,
+        works_quota: 500, scan_quota_monthly: 50, dmca_quota_monthly: 5,
+        scan_frequency: 'daily', has_batch_processing: true, has_trademark_monitoring: true, has_p2p_engine: true, has_legal_consultation: true,
+        createdAt: new Date(), updatedAt: new Date()
+      }
+    ];
+    await queryInterface.bulkInsert('subscription_plans', plans, { ignoreDuplicates: true });
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.bulkDelete('subscription_plans', { plan_code: ['FREE', 'CREATOR', 'CREATOR_PLUS', 'PROFESSIONAL'] });
+  }
+};

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -188,29 +188,29 @@ const HomePage = () => {
       <PageSpacer />
       <HeroWrapper>
         <HeroContainer>
-          <HeroTitle>Blockchain + AI = Flawless Copyright Protection</HeroTitle>
-          <HeroSubtitle>One Click to Prove Your Originality.</HeroSubtitle>
-          <p style={{ maxWidth: '700px', lineHeight: '1.6', fontSize: '1.1rem' }}>
-            <strong>ONLY WE</strong> combine unstoppable <strong>Blockchain Fingerprinting</strong> with advanced <strong>AI Infringement Detection</strong> and global legal solutions, recognized under the <strong>Berne Convention</strong> and <strong>WTO/TRIPS</strong>.
-          </p>
-          <PrimaryButton to="/free-trial">立即免費體驗</PrimaryButton>
+          <HeroTitle>不只保護，更能變現</HeroTitle>
+          <HeroSubtitle>全球首創 P2P 侵權變現引擎，為您的原創著作才華賦予金融價值</HeroSubtitle>
+            <p style={{ maxWidth: '700px', lineHeight: '1.6', fontSize: '1.1rem' }}>
+              我們將不可篡改的區塊鏈存證與 AI 全網監控結合，不僅為您的作品提供無懈可擊的法律保護，更能將每一次侵權，都轉化為您的潛在收益。
+            </p>
+          <PrimaryButton to="/free-trial">立即免費體驗賦權</PrimaryButton>
         </HeroContainer>
       </HeroWrapper>
 
       <FeaturesSection>
-        <SectionTitle>三大核心技術，一站式解決方案</SectionTitle>
+        <SectionTitle>三大核心引擎</SectionTitle>
         <FeaturesContainer>
           <FeatureCard>
-            <FeatureTitle>AI 全網掃描</FeatureTitle>
-            <FeatureText>面對全網的**盜圖**、**盜影片**與**盜版**內容，我們的 AI 引擎提供 24/7 **侵權偵測**。不僅揪出侵權，更能有效**防詐騙濫用**，保護您的品牌形象與數位資產安全。</FeatureText>
+            <FeatureTitle>區塊鏈權狀</FeatureTitle>
+            <FeatureText>告別傳統存證的繁瑣與不確定性。您的每件作品上傳即生成一份全球認可的永久數位產權證明。這不是收據，這是您在數位世界中神聖不可侵犯的**權狀**。</FeatureText>
           </FeatureCard>
           <FeatureCard>
-            <FeatureTitle>區塊鏈存證</FeatureTitle>
-            <FeatureText>您的每一份創作，上傳瞬間即生成不可篡改的數位指紋，永久記錄於區塊鏈。這份鐵證是您最強大的法律後盾，確保您的原創性無可辯駁。</FeatureText>
+            <FeatureTitle>AI 哨兵</FeatureTitle>
+            <FeatureText>我們的 AI 哨兵 24/7 不間斷地巡邏全球網路，從主流社群到各大電商。它不僅是抓賊的眼睛，更是保護您品牌形象、防止詐騙冒用的忠誠衛士。</FeatureText>
           </FeatureCard>
           <FeatureCard>
-            <FeatureTitle>一鍵維權申訴</FeatureTitle>
-            <FeatureText>從發現侵權到法律行動，我們提供真正的**一條龍服務**。整合官方 API，您只需**一鍵即可發動 DMCA 申訴**，要求各大平台將侵權內容下架，流程高效且簡單。</FeatureText>
+            <FeatureTitle>P2P 變現引擎</FeatureTitle>
+            <FeatureText>發現侵權不再只是憤怒。一鍵啟動 P2P 變現引擎，自動生成具備法律效力的解決方案頁面，讓侵權方在「付費授權」與「面臨訴訟」之間做出選擇。您的原創著作權利，現在是可交易的資產。</FeatureText>
           </FeatureCard>
         </FeaturesContainer>
       </FeaturesSection>

--- a/frontend/src/pages/PricingPage.jsx
+++ b/frontend/src/pages/PricingPage.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 
+// ... (Styled-components from previous version)
+
 const PageSpacer = styled.div` min-height: 74px; `;
 const PageWrapper = styled.div` padding: 4rem 2rem; background-color: #f9fafb; `;
 const ContentContainer = styled.div` max-width: 1200px; margin: 0 auto; text-align: center; `;
@@ -46,8 +48,8 @@ const PricingPage = () => {
       <PageWrapper>
         <ContentContainer>
           <Header>
-            <Title>選擇您的專屬保護方案</Title>
-            <Subtitle>您購買的不僅是服務，更是永久的數位資產權。年繳方案僅需支付 10 個月費用，立即享有折扣。</Subtitle>
+            <Title>為您的創作賦權</Title>
+            <Subtitle>您投資的不只是工具，而是您每件作品的永久產權與持續增值的潛力。年繳方案僅需支付 10 個月費用。</Subtitle>
           </Header>
           <PricingGrid>
             <Card>
@@ -59,8 +61,9 @@ const PricingPage = () => {
                 <FeatureItem>每週自動巡檢</FeatureItem>
                 <FeatureItem>每月 <strong>1</strong> 次 DMCA 下架額度</FeatureItem>
                 <FeatureItem>✓ 完整侵權報告</FeatureItem>
+                <FeatureItem>✓ **啟動 P2P 變現引擎**</FeatureItem>
               </FeatureList>
-              <StyledButton onClick={() => handleChoosePlan('CREATOR', 390)}>選擇此方案</StyledButton>
+              <StyledButton onClick={() => handleChoosePlan('CREATOR', 390)}>成為守護者</StyledButton>
             </Card>
             <Card>
               <PlanName>CREATOR+<br/>進階守護者</PlanName>
@@ -71,11 +74,12 @@ const PricingPage = () => {
                 <FeatureItem>每週自動巡檢</FeatureItem>
                 <FeatureItem>每月 <strong>3</strong> 次 DMCA 下架額度</FeatureItem>
                 <FeatureItem>✓ 完整侵權報告</FeatureItem>
+                <FeatureItem>✓ **啟動 P2P 變現引擎**</FeatureItem>
               </FeatureList>
               <StyledButton onClick={() => handleChoosePlan('CREATOR_PLUS', 990)}>選擇此方案</StyledButton>
             </Card>
             <Card featured>
-              <PopularBadge>最受歡迎</PopularBadge>
+              <PopularBadge>最佳價值</PopularBadge>
               <PlanName>PROFESSIONAL<br/>捍衛者方案</PlanName>
               <PlanPrice>NT$ 1,490<span> / 月</span></PlanPrice>
               <FeatureList>
@@ -83,12 +87,12 @@ const PricingPage = () => {
                 <FeatureItem>每月 <strong>50</strong> 次 AI 掃描額度</FeatureItem>
                 <FeatureItem><strong>每日優先掃描</strong></FeatureItem>
                 <FeatureItem>每月 <strong>5</strong> 次 DMCA 下架額度</FeatureItem>
-                <FeatureItem>✓ **啟動 P2P 變現引擎**</FeatureItem>
-                <FeatureItem>✓ 批量處理工具</FeatureItem>
-                <FeatureItem>✓ 商標監測功能</FeatureItem>
-                <FeatureItem>✓ Email 法律諮詢</FeatureItem>
+                <FeatureItem>✅ **進階 P2P 變現引擎**</FeatureItem>
+                <FeatureItem>✅ 批量處理工具</FeatureItem>
+                <FeatureItem>✅ 商標監測功能</FeatureItem>
+                <FeatureItem>✅ Email 法律諮詢</FeatureItem>
               </FeatureList>
-              <StyledButton featured onClick={() => handleChoosePlan('PROFESSIONAL', 1490)}>升級捍衛者方案</StyledButton>
+              <StyledButton featured onClick={() => handleChoosePlan('PROFESSIONAL', 1490)}>升級為捍衛者</StyledButton>
             </Card>
           </PricingGrid>
         </ContentContainer>


### PR DESCRIPTION
## Summary
- update subscription plan model fields
- add strategic subscription plan seed data
- rewrite homepage hero and features for P2P engine messaging
- overhaul pricing page with final decoy pricing details

## Testing
- `pnpm lint`
- `pnpm test` *(fails: 3 test suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_68808a76cddc832483abbaed87df8c32