### PR TITLE
Improve CLI logging and debugging

### DIFF
--- a/express/cli.js
+++ b/express/cli.js
@@ -97,7 +97,7 @@ program
       await user.save();
       logger.info(`[CLI] 已成功為 ${email} 重設密碼。`);
     } catch (error) {
-      logger.error('[CLI] 重設密碼失敗:', error.message);
+      logger.error('[CLI] 重設密碼失敗:', error);
     } finally {
       // 確保資料庫連線在使用後關閉
       await sequelize.close();
@@ -124,6 +124,11 @@ program
       console.log('[CLI] 嘗試驗證資料庫連線...');
       await sequelize.authenticate();
       console.log('[CLI] 資料庫連線成功');
+
+      // 調試：列出所有用戶
+      const allUsers = await User.findAll({ attributes: ['id', 'email'] });
+      console.log('[CLI] 資料庫中的用戶列表:');
+      allUsers.forEach(u => console.log(`  ${u.id}: ${u.email}`));
 
       console.log(`[CLI] 搜尋使用者: ${email}`);
       const user = await User.findOne({


### PR DESCRIPTION
## Summary
- improve error logging for password reset command
- list all users when testing login for debugging purposes

## Testing
- `npm test` *(fails: cannot find gcp-vision.json and auth tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_68811c4657048324998b3f819526e89a