### PR TITLE
Fix header logo path

### DIFF
--- a/frontend/src/components/Blog/Header.jsx
+++ b/frontend/src/components/Blog/Header.jsx
@@ -128,7 +128,7 @@ const Header = () => {
     <HeaderWrapper>
       <Toolbar>
         <LogoLink to="/" onClick={closeMenu}>
-          <img src="/suzoo-logo-transparent.png" alt="SUZOO IP Guard Logo" style={{ height: '40px', marginRight: '10px' }} />
+          <img src="/suzoo-logo.png" alt="SUZOO IP Guard Logo" style={{ height: '40px', marginRight: '10px' }} />
           <span style={{ fontWeight: 'bold', fontSize: '1.5rem' }}>SUZOO IP Guard</span>
         </LogoLink>
         <NavLinks>


### PR DESCRIPTION
## Summary
- point header logo to existing `suzoo-logo.png`

## Testing
- `pnpm install` & `pnpm test` in `frontend` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688288d3de6c832485b93737849e6c24