### PR TITLE
Add Deepfake article and author signature component

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -44,6 +44,7 @@ import BlockchainEvidenceLegalValidity from './pages/blog/BlockchainEvidenceLega
 import MythBusterArticle from './pages/blog/MythBusterArticle';
 import P2PEngineCaseStudy from './pages/blog/P2PEngineCaseStudy';
 import UserTestimonialArticle from './pages/blog/UserTestimonialArticle';
+import ScamNemesisArticle from './pages/blog/ScamNemesisArticle';
 import NotFoundPage from './pages/NotFoundPage';
 
 // Components
@@ -82,6 +83,7 @@ function App() {
                 <Route path="/blog/ai-artwork-copyright-guide" element={<AiArtworkCopyrightGuide />} />
                 <Route path="/blog/ecommerce-image-theft-prevention" element={<EcommerceImageTheftPrevention />} />
                 <Route path="/blog/blockchain-evidence-legal-validity" element={<BlockchainEvidenceLegalValidity />} />
+                <Route path="/blog/scam-nemesis-deepfake-protection" element={<ScamNemesisArticle />} />
                 <Route path="/blog/copyright-myths-buster" element={<MythBusterArticle />} />
                 <Route path="/blog/p2p-engine-case-study" element={<P2PEngineCaseStudy />} />
                 <Route path="/blog/user-testimonial-ai-sentinel" element={<UserTestimonialArticle />} />

--- a/frontend/src/components/ArticleSignature.jsx
+++ b/frontend/src/components/ArticleSignature.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const SignatureWrapper = styled.div`
+  margin-top: 4rem;
+  padding-top: 2rem;
+  border-top: 1px solid #e5e7eb;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+`;
+
+const LogoImage = styled.img`
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  object-fit: cover;
+`;
+
+const AuthorInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const AuthorName = styled.p`
+  margin: 0;
+  font-weight: bold;
+  color: #111;
+`;
+
+const AuthorTitle = styled.p`
+  margin: 0;
+  font-size: 0.9rem;
+  color: #6b7280;
+`;
+
+const ArticleSignature = () => {
+  return (
+    <SignatureWrapper>
+      <LogoImage src="/suzoo-logo.png" alt="SUZOO IP Guard Logo" />
+      <AuthorInfo>
+        <AuthorName>Zack Yao</AuthorName>
+        <AuthorTitle>SUZOO IP Guard 創辦人 & CEO</AuthorTitle>
+      </AuthorInfo>
+    </SignatureWrapper>
+  );
+};
+
+export default ArticleSignature;

--- a/frontend/src/pages/BlogIndexPage.jsx
+++ b/frontend/src/pages/BlogIndexPage.jsx
@@ -52,7 +52,13 @@ const articles = [
         slug: 'user-testimonial-ai-sentinel',
         title: '用戶見證：身為全職插畫家，SUZOO 的「AI 哨兵」每月為我省下超過 20 小時的人工搜圖時間。',
         excerpt: '知名圖文作家 Isabelle 分享她如何利用 SUZOO 的 AI 哨兵功能，擺脫手動搜圖的惱人流程，專注於創作本身。'
-    }
+    },
+    {
+        id: 7,
+        slug: 'scam-nemesis-deepfake-protection',
+        title: '詐騙集團剋星！SUZOO 如何斬斷伸向網紅與名人的 AI 黑產鏈？',
+        excerpt: '您是否曾在社群上看過名人用逼真的聲音和嘴型，推薦可疑的產品？這很可能不是本人！本文揭示 AI 深度偽造詐騙的原理，並提供最前沿的應對策略。'
+    },
 ];
 
 const BlogIndexPage = () => {

--- a/frontend/src/pages/blog/AiArtworkCopyrightGuide.jsx
+++ b/frontend/src/pages/blog/AiArtworkCopyrightGuide.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 
+import ArticleSignature from '../../components/ArticleSignature';
 const PageSpacer = styled.div` min-height: 74px; `;
 const ArticleWrapper = styled.div` padding: 4rem 2rem; background: white; `;
 const ArticleContainer = styled.article` max-width: 800px; margin: 0 auto; line-height: 1.8; font-size: 1.1rem; `;
@@ -52,6 +53,7 @@ const AiArtworkCopyrightGuide = () => {
                     <p>You may spend hours refining, combining, and iterating hundreds of prompts to create the perfect image. This process involves your aesthetic judgment, semantic understanding, and goal-oriented creativity. This entire <strong>creative process</strong> is intellectual property that deserves protection. When a dispute arises, you're not just proving ownership of the final image, but that you were the <strong>first person to execute that specific creative act</strong>.</p>
                     <h4>How to Protect Yourself with SUZOO</h4>
                     <p>The smartest move is to create an indestructible evidence trail for your creative process. SUZOO IP Guard allows you to generate a permanent blockchain deed for your final work, complete with your key prompts and a timestamp, giving you the strongest possible evidence of being the "first creator" in any dispute.</p>
+    <ArticleSignature />
                 </ArticleContainer>
             </ArticleWrapper>
         </>

--- a/frontend/src/pages/blog/BlockchainEvidenceLegalValidity.jsx
+++ b/frontend/src/pages/blog/BlockchainEvidenceLegalValidity.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 
+import ArticleSignature from '../../components/ArticleSignature';
 const PageSpacer = styled.div` min-height: 74px; `;
 const ArticleWrapper = styled.div` padding: 4rem 2rem; background: white; `;
 const ArticleContainer = styled.article` 
@@ -114,6 +115,7 @@ const BlockchainEvidenceLegalValidity = () => {
                         <li><strong>Originality:</strong> The neutral, network-verified timestamp provides powerful proof of your creation/possession date, helping you establish priority in copyright disputes.</li>
                     </ol>
                     <p>SUZOO IP Guard simplifies this entire complex process into a single click, empowering you with this top-tier legal weapon without needing to be a cryptography expert.</p>
+            <ArticleSignature />
                 </ArticleContainer>
             </ArticleWrapper>
         </>

--- a/frontend/src/pages/blog/ScamNemesisArticle.jsx
+++ b/frontend/src/pages/blog/ScamNemesisArticle.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+import ArticleLayout, { ArticleMeta, CTASection, PrimaryButton } from '../../layouts/ArticleLayout';
+import ArticleSignature from '../../components/ArticleSignature';
+
+const ScamNemesisArticle = () => {
+    const navigate = useNavigate();
+
+    return (
+        <ArticleLayout>
+            <h1>詐騙集團剋星！SUZOO 如何斬斷伸向網紅與名人的 AI 黑產鏈？</h1>
+            <ArticleMeta>發布日期：2025年7月25日 | 閱讀時間：約 5 分鐘</ArticleMeta>
+            
+            <p><strong>前言：</strong>您是否曾在 Facebook 上看過某位知名網紅，用極其逼真的聲音和嘴型，推薦一款來路不明的投資產品？這很可能不是他本人，而是詐騙集團利用 AI 深度偽造技術製作的假影片。這種新型態的詐騙不僅嚴重侵害名人的肖像權與聲譽，更讓無數粉絲受騙。傳統的「事後報警」早已跟不上 AI 的犯罪速度，我們需要更前沿的武器。</p>
+
+            <h2>AI 詐騙的運作原理</h2>
+            <p>詐騙集團僅需取得目標人物數分鐘的公開影片和聲音樣本，就能利用 AI 技術進行聲音複製 (Voice Cloning)、臉部替換 (Face Swapping) 與嘴型同步 (Lip Syncing)，產出幾可亂真的假冒影片。</p>
+            
+            <h2>SUZOO 的解決方案：建立「官方正本」的權威認證庫</h2>
+            <p>面對 AI 生成的「假內容」，最好的反擊不是去證明「它是假的」，而是建立一個讓任何人都能輕鬆驗證<strong>「什麼才是真的」</strong>的系統。這就是 SUZOO 的核心戰略：</p>
+            <ol>
+                <li><strong>事前主動存證</strong>：我們強烈建議所有公眾人物、網紅與經紀公司，將其<strong>官方發布</strong>的影片、照片甚至聲音樣本，第一時間在 SUZOO 進行<strong>區塊鏈存證</strong>。這相當於為每一份「正版內容」都蓋上了一個無法偽造的數位鋼印。</li>
+                <li><strong>建立信任標章</strong>：您的官方網站、社群媒體都可以掛上<strong>「SUZOO 認證內容發布者」</strong>的徽章。您可以教育您的粉絲，只相信那些可以連結到 SUZOO 區塊鏈權狀的內容。</li>
+                <li><strong>反向打擊</strong>：當詐騙影片出現時，您不再是空口白話地向平台檢舉。您可以出示您在<strong>詐騙影片出現之前</strong>就已完成存證的、大量的「正版」作品集，這形成了強而有力的法律證據鏈，證明您才是原創者，而對方是惡意合成。</li>
+            </ol>
+            
+            <CTASection>
+                <h3>在 AI 時代，定義真實，就是定義權利</h3>
+                <p>不要等到您的臉孔和聲音成為詐騙工具時才採取行動。預防勝於治療。</p>
+                <PrimaryButton onClick={() => navigate('/contact')}>立即聯繫我們，為您的品牌形象建立區塊鏈防護網</PrimaryButton>
+            </CTASection>
+
+            <ArticleSignature />
+        </ArticleLayout>
+    );
+};
+
+export default ScamNemesisArticle;


### PR DESCRIPTION
## Summary
- add reusable `ArticleSignature` component
- publish new blog post `ScamNemesisArticle`
- display article signature on multiple posts
- list new post on blog index
- register route for new article

## Testing
- `CI=true npm test` *(fails: could not resolve workspaces)*
- `CI=true npm test` in `frontend` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6882eeff40888324a7a4f31da597729d