### PR TITLE
Add feature pages

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -37,6 +37,10 @@ import DmcaPage from './pages/solutions/DmcaPage';
 import BlockchainDeedPage from './pages/solutions/BlockchainDeedPage';
 import AiSentinelPage from './pages/solutions/AiSentinelPage';
 import P2pEnginePage from './pages/solutions/P2pEnginePage';
+// 新增 AI 偵測三大功能頁面
+import GlobalCoveragePage from './pages/solutions/GlobalCoveragePage';
+import SmartMatchingPage from './pages/solutions/SmartMatchingPage';
+import RealtimeAlertsPage from './pages/solutions/RealtimeAlertsPage';
 import BlogIndexPage from './pages/BlogIndexPage';
 import AiArtworkCopyrightGuide from './pages/blog/AiArtworkCopyrightGuide';
 import EcommerceImageTheftPrevention from './pages/blog/EcommerceImageTheftPrevention';
@@ -95,9 +99,12 @@ function App() {
                 <Route path="/protect/step3" element={<ProtectStep3 />} />
                 <Route path="/protect/step4" element={<ProtectStep4 />} />
                 <Route path="/solutions/ai-detection" element={<AiDetectionPage />} />
+                {/* 新增三大功能詳情頁路由 */}
+                <Route path="/solutions/global-coverage" element={<GlobalCoveragePage />} />
+                <Route path="/solutions/smart-matching" element={<SmartMatchingPage />} />
+                <Route path="/solutions/realtime-alerts" element={<RealtimeAlertsPage />} />
                 <Route path="/solutions/blockchain" element={<BlockchainPage />} />
                 <Route path="/solutions/dmca-takedown" element={<DmcaPage />} />
-                {/* 新增三大功能詳情頁路由 */}
                 <Route path="/solutions/blockchain-deed" element={<BlockchainDeedPage />} />
                 <Route path="/solutions/ai-sentinel" element={<AiSentinelPage />} />
                 <Route path="/solutions/p2p-engine" element={<P2pEnginePage />} />

--- a/frontend/src/pages/solutions/AiDetectionPage.jsx
+++ b/frontend/src/pages/solutions/AiDetectionPage.jsx
@@ -2,101 +2,83 @@ import React from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 
-const PageSpacer = styled.div`min-height: 74px;`;
-const HeroSection = styled.section`
-  padding: 80px 32px;
-  background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
-  text-align: center;
+const PageSpacer = styled.div` min-height: 74px; `;
+const PageWrapper = styled.div` padding: 4rem 2rem; background-color: #f9fafb; `;
+const ContentContainer = styled.div` max-width: 1200px; margin: 0 auto; text-align: center; `;
+const Header = styled.header` margin-bottom: 4rem; `;
+const Title = styled.h1` font-size: 3rem; font-weight: 800; margin-bottom: 1rem; `;
+const Subtitle = styled.p` font-size: 1.25rem; color: #6b7280; max-width: 700px; margin: 0 auto; line-height: 1.6; `;
+
+const FeaturesGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 2.5rem;
 `;
-const ContentContainer = styled.div`
-  max-width: 900px;
-  margin: 0 auto;
-`;
-const Title = styled.h1`
-  font-size: 3rem;
-  font-weight: 800;
-  color: #1F2937;
-`;
-const Subtitle = styled.p`
-  font-size: 1.25rem;
-  color: #4B5563;
-  margin-top: 1rem;
-`;
-const CtaButton = styled(Link)`
-  display: inline-block;
-  margin-top: 2rem;
-  padding: 14px 28px;
-  font-size: 1.1rem;
-  font-weight: 600;
-  color: #FFFFFF;
-  background-color: #D45398;
+
+const FeatureCard = styled(Link)`
+  background: white;
+  border: 1px solid #E5E7EB;
   border-radius: 12px;
+  padding: 2.5rem 2rem;
+  text-align: center;
   text-decoration: none;
-  box-shadow: 0 4px 15px rgba(212, 83, 152, 0.3);
+  color: inherit;
+  box-shadow: 0 4px 6px rgba(0,0,0,0.05);
   transition: all 0.3s ease;
+
   &:hover {
-    transform: translateY(-3px);
-    box-shadow: 0 6px 20px rgba(212, 83, 152, 0.4);
+    transform: translateY(-10px);
+    box-shadow: 0 10px 25px rgba(0,0,0,0.1);
+    border-color: #D45398;
   }
 `;
 
-const FeatureSection = styled.section`
-  padding: 80px 32px;
-  background: #FFFFFF;
+const FeatureIcon = styled.div`
+  font-size: 3rem;
+  margin-bottom: 1.5rem;
 `;
 
-const FeatureGrid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 2rem;
-  max-width: 1200px;
-  margin: 0 auto;
+const FeatureTitle = styled.h2`
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #111827;
+  margin-bottom: 1rem;
 `;
 
-const FeatureCard = styled.div`
-  background: #f9fafb;
-  border: 1px solid #e5e7eb;
-  border-radius: 16px;
-  padding: 2rem;
-  text-align: center;
+const FeatureDescription = styled.p`
+  color: #374151;
+  line-height: 1.7;
 `;
-
-const FeatureIcon = styled.div` font-size: 3rem; margin-bottom: 1rem; `;
-const FeatureTitle = styled.h3` font-size: 1.5rem; color: #1F2937; `;
-const FeatureText = styled.p` color: #6B7280; line-height: 1.6; `;
 
 const AiDetectionPage = () => {
   return (
     <>
       <PageSpacer />
-      <HeroSection>
+      <PageWrapper>
         <ContentContainer>
-          <Title>AI 全網侵權偵測：您的 24/7 數位守護者</Title>
-          <Subtitle>
-            我們的 AI 引擎永不休息，持續掃描全球主流社群平台與各大網站，自動揪出盜用您珍貴作品的盜圖、盜影片行為，讓侵權無所遁形。
-          </Subtitle>
-          <CtaButton to="/protect/step1">立即免費體驗 AI 偵測</CtaButton>
+          <Header>
+            <Title>AI 哨兵：您的 24/7 全網保護神</Title>
+            <Subtitle>我們的 AI 侵權偵測系統，不僅是一個工具，更是您在數位世界中不眠不休的忠誠衛士。探索其三大核心能力，了解我們如何為您的創作建立起堅不可摧的防線。</Subtitle>
+          </Header>
+          <FeaturesGrid>
+            <FeatureCard to="/solutions/global-coverage">
+              <FeatureIcon>🌐</FeatureIcon>
+              <FeatureTitle>全球覆蓋巡邏網</FeatureTitle>
+              <FeatureDescription>深入掃描 Facebook, Instagram, YouTube, TikTok 及各大電商網站，全面防堵盜版內容，有效防範您的品牌形象被詐騙集團濫用。</FeatureDescription>
+            </FeatureCard>
+            <FeatureCard to="/solutions/smart-matching">
+              <FeatureIcon>💡</FeatureIcon>
+              <FeatureTitle>智慧指紋比對技術</FeatureTitle>
+              <FeatureDescription>不僅僅是關鍵字。我們的 AI 採用先進的圖像與影片指紋比對技術，即使作品被裁切、調色或修改，也能精準識別。</FeatureDescription>
+            </FeatureCard>
+            <FeatureCard to="/solutions/realtime-alerts">
+              <FeatureIcon>🔔</FeatureIcon>
+              <FeatureTitle>即時威脅警報系統</FeatureTitle>
+              <FeatureDescription>一旦發現疑似侵權內容，系統將第一時間透過儀表板與 Email 通知您，讓您即時掌握狀況，在損害擴大前採取行動。</FeatureDescription>
+            </FeatureCard>
+          </FeaturesGrid>
         </ContentContainer>
-      </HeroSection>
-      <FeatureSection>
-        <FeatureGrid>
-          <FeatureCard>
-            <FeatureIcon>🌐</FeatureIcon>
-            <FeatureTitle>全球覆蓋</FeatureTitle>
-            <FeatureText>深入掃描 Facebook, Instagram, YouTube, TikTok 及各大電商網站，全面防堵盜版內容，有效防範品牌形象被詐騙集團濫用。</FeatureText>
-          </FeatureCard>
-          <FeatureCard>
-            <FeatureIcon>💡</FeatureIcon>
-            <FeatureTitle>智慧比對技術</FeatureTitle>
-            <FeatureText>不僅僅是關鍵字，我們的 AI 採用先進的圖像與影片指紋比對技術，即使作品被裁切、調色或修改，也能精準識別。</FeatureText>
-          </FeatureCard>
-          <FeatureCard>
-            <FeatureIcon>🔔</FeatureIcon>
-            <FeatureTitle>即時警報系統</FeatureTitle>
-            <FeatureText>一旦發現疑似侵權內容，系統將第一時間透過儀表板與 Email 通知您，讓您即時掌握狀況，採取行動。</FeatureText>
-          </FeatureCard>
-        </FeatureGrid>
-      </FeatureSection>
+      </PageWrapper>
     </>
   );
 };

--- a/frontend/src/pages/solutions/GlobalCoveragePage.jsx
+++ b/frontend/src/pages/solutions/GlobalCoveragePage.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+
+const PageSpacer = styled.div` min-height: 74px; `;
+const PageWrapper = styled.div` padding: 4rem 2rem; background-color: #f9fafb; `;
+const ContentContainer = styled.div` max-width: 1200px; margin: 0 auto; text-align: center; `;
+const Header = styled.header` margin-bottom: 4rem; `;
+const Title = styled.h1` font-size: 3rem; font-weight: 800; margin-bottom: 1rem; `;
+const Subtitle = styled.p` font-size: 1.25rem; color: #6b7280; max-width: 700px; margin: 0 auto; line-height: 1.6; `;
+
+const Section = styled.section` margin: 3rem 0; text-align: left; `;
+const SectionTitle = styled.h2` font-size: 2rem; margin-bottom: 1rem; color: #D45398; `;
+const CTASection = styled.div`
+  background: #EBB0CF;
+  padding: 2rem;
+  border-radius: 12px;
+  text-align: center;
+  margin-top: 2rem;
+`;
+const PrimaryButton = styled.button`
+  margin-top: 1rem;
+  padding: 14px 28px;
+  font-weight: 600;
+  border: none;
+  background: #D45398;
+  color: #FFFFFF;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  &:hover { opacity: 0.9; transform: scale(1.03); }
+`;
+
+const GlobalCoveragePage = () => {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <PageSpacer />
+      <PageWrapper>
+        <ContentContainer>
+          <Header>
+            <Title>全球覆蓋巡邏網：讓侵權無所遁形</Title>
+            <Subtitle>在網路世界，地理疆界已無意義。您的作品可能在下一秒就出現在地球另一端的詐騙網站上。因此，您的保護網也必須是全球級的。</Subtitle>
+          </Header>
+          <Section>
+            <SectionTitle>我們的 AI 哨兵在哪裡巡邏？</SectionTitle>
+            <p>SUZOO 的 AI 哨兵部署在全球數千台雲端伺服器上，24/7 不間斷地掃描以下高風險區域：</p>
+            <ul>
+              <li><strong>主流社群媒體</strong>: Facebook, Instagram, X (Twitter), Pinterest</li>
+              <li><strong>影音平台</strong>: YouTube, TikTok, Vimeo</li>
+              <li><strong>亞洲主要電商平台</strong>: 蝦皮 (Shopee), 淘寶 (Taobao), MOMO, PChome</li>
+              <li><strong>全球獨立電商</strong>: 數以萬計使用 Shopify, WooCommerce 建立的一頁式網站</li>
+            </ul>
+            <p>我們的監控列表每週都在擴大，確保能覆蓋最新的威脅來源。</p>
+          </Section>
+          <CTASection>
+            <h3>您的創作值得世界級的保護</h3>
+            <p>不要讓您的心血結晶，成為您不知道的角落裡，他人獲利的工具。立即部署您的全球 AI 哨兵，將整個網路納入您的保護範圍。</p>
+            <PrimaryButton onClick={() => navigate('/pricing')}>查看方案，啟動全球防護</PrimaryButton>
+          </CTASection>
+        </ContentContainer>
+      </PageWrapper>
+    </>
+  );
+};
+export default GlobalCoveragePage;

--- a/frontend/src/pages/solutions/RealtimeAlertsPage.jsx
+++ b/frontend/src/pages/solutions/RealtimeAlertsPage.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+
+const PageSpacer = styled.div` min-height: 74px; `;
+const PageWrapper = styled.div` padding: 4rem 2rem; background-color: #f9fafb; `;
+const ContentContainer = styled.div` max-width: 1200px; margin: 0 auto; text-align: center; `;
+const Header = styled.header` margin-bottom: 4rem; `;
+const Title = styled.h1` font-size: 3rem; font-weight: 800; margin-bottom: 1rem; `;
+const Subtitle = styled.p` font-size: 1.25rem; color: #6b7280; max-width: 700px; margin: 0 auto; line-height: 1.6; `;
+
+const Section = styled.section` margin: 3rem 0; text-align: left; `;
+const SectionTitle = styled.h2` font-size: 2rem; margin-bottom: 1rem; color: #D45398; `;
+const CTASection = styled.div`
+  background: #EBB0CF;
+  padding: 2rem;
+  border-radius: 12px;
+  text-align: center;
+  margin-top: 2rem;
+`;
+const PrimaryButton = styled.button`
+  margin-top: 1rem;
+  padding: 14px 28px;
+  font-weight: 600;
+  border: none;
+  background: #D45398;
+  color: #FFFFFF;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  &:hover { opacity: 0.9; transform: scale(1.03); }
+`;
+
+const RealtimeAlertsPage = () => {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <PageSpacer />
+      <PageWrapper>
+        <ContentContainer>
+          <Header>
+            <Title>即時威脅警報：在黃金時間內採取行動</Title>
+            <Subtitle>在侵權事件中，時間就是一切。晚一天處理，可能就意味著數百位消費者受騙，或您的作品被二次傳播到無法控制的範圍。SUZOO 的即時警報系統，就是為了幫您贏回時間主導權。</Subtitle>
+          </Header>
+          <Section>
+            <SectionTitle>從「發現」到「行動」，零時差</SectionTitle>
+            <p>忘掉每週手動搜尋一次的低效模式。SUZOO 的運作流程是全自動化的：</p>
+            <ol>
+              <li><strong>AI 哨兵發現威脅</strong>: 我們的系統在全球網路中發現疑似侵權的內容。</li>
+              <li><strong>系統立即通知</strong>: 在幾分鐘內，您的會員儀表板會出現紅點提示，同時一封詳細的警報 Email 會發送到您的信箱。</li>
+              <li><strong>一鍵進入戰情室</strong>: 您可以直接從 Email 中的連結，登入到 SUZOO 的「維權案件管理」介面，看到所有被整理好的侵權證據。</li>
+              <li><strong>立即採取行動</strong>: 您可以立刻決定，是要啟動 P2P 變現引擎，還是發動 DMCA 下架申訴。</li>
+            </ol>
+            <p>我們將原本需要數小時甚至數天的繁瑣流程，縮短為您只需幾分鐘即可完成的決策，這就是在數位戰爭中致勝的關鍵。</p>
+          </Section>
+          <CTASection>
+            <h3>停止被動等待，開始主動出擊</h3>
+            <p>侵權不會等你。立即升級您的方案，啟用即時警報與 P2P 變現引擎，將每一次威脅，都轉化為您展現權利與創造價值的機會。</p>
+            <PrimaryButton onClick={() => navigate('/pricing')}>查看方案，升級您的反應速度</PrimaryButton>
+          </CTASection>
+        </ContentContainer>
+      </PageWrapper>
+    </>
+  );
+};
+export default RealtimeAlertsPage;

--- a/frontend/src/pages/solutions/SmartMatchingPage.jsx
+++ b/frontend/src/pages/solutions/SmartMatchingPage.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+
+const PageSpacer = styled.div` min-height: 74px; `;
+const PageWrapper = styled.div` padding: 4rem 2rem; background-color: #f9fafb; `;
+const ContentContainer = styled.div` max-width: 1200px; margin: 0 auto; text-align: center; `;
+const Header = styled.header` margin-bottom: 4rem; `;
+const Title = styled.h1` font-size: 3rem; font-weight: 800; margin-bottom: 1rem; `;
+const Subtitle = styled.p` font-size: 1.25rem; color: #6b7280; max-width: 700px; margin: 0 auto; line-height: 1.6; `;
+
+const Section = styled.section` margin: 3rem 0; text-align: left; `;
+const SectionTitle = styled.h2` font-size: 2rem; margin-bottom: 1rem; color: #D45398; `;
+const CTASection = styled.div`
+  background: #EBB0CF;
+  padding: 2rem;
+  border-radius: 12px;
+  text-align: center;
+  margin-top: 2rem;
+`;
+const PrimaryButton = styled.button`
+  margin-top: 1rem;
+  padding: 14px 28px;
+  font-weight: 600;
+  border: none;
+  background: #D45398;
+  color: #FFFFFF;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  &:hover { opacity: 0.9; transform: scale(1.03); }
+`;
+
+const SmartMatchingPage = () => {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <PageSpacer />
+      <PageWrapper>
+        <ContentContainer>
+          <Header>
+            <Title>智慧指紋比對：看穿侵權者的偽裝</Title>
+            <Subtitle>盜圖者最常用的伎倆就是對您的作品進行微調：加上濾鏡、左右翻轉、稍微裁切，試圖躲過傳統的搜尋引擎。我們的智慧比對技術，就是為此而生。</Subtitle>
+          </Header>
+          <Section>
+            <SectionTitle>為何我們能比 Google 更精準？</SectionTitle>
+            <p>當您上傳作品時，SUZOO 不僅儲存您的圖片，更會為其計算出一個獨一無二的<strong>「感知雜湊」(Perceptual Hash)</strong>。這就像是作品的 DNA，它記錄的不是像素，而是圖像的結構、比例與色彩分佈。這意味著：</p>
+            <ul>
+              <li><strong>對抗裁切</strong>: 即使圖片被裁切掉 30%，其核心指紋依然存在。</li>
+              <li><strong>無視調色</strong>: 無論是變成黑白、加上 LOMO 濾鏡，都不會影響指紋的比對。</li>
+              <li><strong>抵抗翻轉與壓縮</strong>: 圖片被左右翻轉或經過嚴重壓縮，我們的 AI 依然能認出它。</li>
+            </ul>
+            <p>這項技術讓我們能揪出那些人類肉眼難以分辨、但本質上就是盜用您心血的侵權內容。</p>
+          </Section>
+          <CTASection>
+            <h3>魔高一尺，道高一丈</h3>
+            <p>不要讓侵權者的雕蟲小技逍遙法外。立即體驗 SUZOO 的智慧指紋比對技術，讓您的每一份創作都擁有無法被偽裝的數位 DNA。</p>
+            <PrimaryButton onClick={() => navigate('/free-trial')}>免費體驗精準偵測</PrimaryButton>
+          </CTASection>
+        </ContentContainer>
+      </PageWrapper>
+    </>
+  );
+};
+export default SmartMatchingPage;


### PR DESCRIPTION
## Summary
- convert AI detection page into a hub linking to detailed pages
- add Global Coverage, Smart Matching and Realtime Alerts pages
- route new pages in the app

## Testing
- `pnpm lint`
- `pnpm test` *(fails: `suzoo-express` tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6882f091a7c0832492d88e824e79f5f3